### PR TITLE
install.sh: Use env(1) to locate bash(1)

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 curl -o install.escript https://raw.githubusercontent.com/novaframework/rebar3_nova/master/install.escript
 chmod +x install.escript


### PR DESCRIPTION
Bash may be installed elsewhere than `/bin`. For instance, its default location on FreeBSD is `/usr/local/bin/bash`.