### PR TITLE
Use translate3d instead of translateY to get GPU support

### DIFF
--- a/priv/templates/nova/controller.dtl
+++ b/priv/templates/nova/controller.dtl
@@ -81,10 +81,10 @@
 
       @keyframes animStar {
           from {
-              transform: translateY(0px);
+              transform: translate3d(0, 0px, 0);
           }
           to {
-              transform: translateY(-2000px);
+              transform: translateY(0, -2000px, 0);
           }
       }
     </style>


### PR DESCRIPTION
This makes the default page run a little nicer on machines with slow CPUs