### PR TITLE
Updated templates to generate correct names, changed cookie in vm.args

### DIFF
--- a/priv/templates/nova/plugin.erl
+++ b/priv/templates/nova/plugin.erl
@@ -1,4 +1,4 @@
--module({{pluginname}}_plugin).
+-module({{name}}_plugin).
 -behaviour(nova_plugin).
 
 -export([

--- a/priv/templates/nova/vm.args.src
+++ b/priv/templates/nova/vm.args.src
@@ -1,6 +1,6 @@
 -sname '{{name}}'
 
--setcookie '{{name}}_cookie'
+-setcookie {{name}}_cookie
 
 +K true
 +A30


### PR DESCRIPTION
When creating new plugins the name in `-module()` was wrong.

Changed the cookie.