### PR TITLE
[rebar3] Make plugin a bit more robust

### DIFF
--- a/src/rebar3_nova.erl
+++ b/src/rebar3_nova.erl
@@ -6,11 +6,14 @@
 init(State) ->
     {ok, Vsn} = application:get_key(rebar, vsn),
     case parse_version(Vsn) of
-        [Major, Minor, _Patch] when Major >= "3" andalso
+        [Major, Minor| _Patch] when Major >= "3" andalso
                                    Minor > "15" ->
             lists:foldl(fun provider_init/2, {ok, State}, [rebar3_nova_prv, rebar3_nova_serve, rebar3_nova_routes]);
-        _ ->
-            rebar_api:abort("Nova needs Rebar > 3.15 to function. Your version is: ~p. Please consider upgrading.", [Vsn])
+        ["git"] ->
+            rebar_api:info("Compiling with rebar3 from git - make sure you know what you are doing"),
+            lists:foldl(fun provider_init/2, {ok, State}, [rebar3_nova_prv, rebar3_nova_serve, rebar3_nova_routes]);
+        SomethingElse ->
+            rebar_api:abort("Nova needs Rebar > 3.15 to function. Your version is: ~p. Please consider upgrading.", [SomethingElse])
     end.
 
 provider_init(Module, {ok, State}) ->


### PR DESCRIPTION
If user has rebar3 checked out from git it becomes difficult to compile the nova-plugin especially if it is inside the ~/.config/rebar3/rebar.config file.

```
===> "nova-xperiments/hello_mundo/_build/default/plugins/pmod_transform/ebin/pmod_transform.app" is missing applications entry
===> Nova needs Rebar > 3.15 to function. Your version is: "3.25.1+build.5478.refb62659be". Please consider upgrading.
===> Failed creating providers. Run with DIAGNOSTIC=1 for stacktrace or consult rebar3.crashdump.
```

Case 1: Rebar3 during compiling states it comes from 'git'.

Case 2: Rebar3 is more verbose in the version number and
        does not return a 'pretty' Major.Minor.Patch string.

The code now only takes into account Major and Minor discarding all the other String which came back from the parse_version function.

One could test this with rebar3 checked out from github:

```
$ rebar3 -v
rebar 3.25.1+build.5478.refb62659be on Erlang/OTP 28 Erts 16.0.1
```