### PR TITLE
Add generator, introspection, and release commands

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,37 +7,234 @@ A rebar plugin for nova
 
     $ rebar3 compile
 
-## Basic usage
+## Installation
 
-Add the plugin to your rebar config ( ~/.config/rebar3/rebar.config):
+Add the plugin to your rebar config (`~/.config/rebar3/rebar.config`):
 
     {plugins, [
         {rebar3_nova, {git, "https://github.com/novaframework/rebar3_nova.git", {branch, "master"}}}
     ]}.
 
 For latest stable from hex:
-    
+
     {plugins, [rebar3_nova]}.
 
 Then just call your plugin directly in an existing application:
 
-
     $ rebar3 nova
     ===> Fetching rebar3_nova
     ===> Compiling rebar3_nova
-    <Plugin Output>
 
-## Use auto-reload
+## Commands
 
-Nova comes with a auto-reload mechanism that compiles and reloads code that is changed during runtime. This decreases the overall time when developing.
+### `nova serve` — Auto-reload development server
+
+Starts the application with auto-reload. Source file changes are automatically compiled and hot-loaded.
 
 ```
 $ rebar3 nova serve
-===> Verifying dependencies...
-...
-Erlang/OTP 20 [erts-9.3] [source] [64-bit] [smp:8:8] [ds:8:8:10] [async-threads:0] [hipe] [kernel-poll:false] [dtrace]
-
-Eshell V9.3  (abort with ^G)
-1> ===> The rebar3 shell is a development tool; to deploy applications in production, consider using releases (http://www.rebar3.org/docs/releases)
-...
 ```
+
+### `nova routes` — List compiled routes
+
+Displays the compiled routing tree with methods, paths, and handler modules.
+
+```
+$ rebar3 nova routes
+```
+
+### `nova gen_controller` — Generate a controller
+
+Scaffolds a controller module with stub functions for CRUD actions.
+
+```
+$ rebar3 nova gen_controller --name users
+===> Created src/controllers/myapp_users_controller.erl
+
+$ rebar3 nova gen_controller --name users --actions list,show
+===> Created src/controllers/myapp_users_controller.erl
+```
+
+**Options:**
+
+| Flag | Required | Default | Description |
+|------|----------|---------|-------------|
+| `--name`, `-n` | yes | — | Controller name |
+| `--actions`, `-a` | no | `list,show,create,update,delete` | Comma-separated actions to generate |
+
+Generated functions return stub responses:
+- `list/1`, `show/1`, `update/1` return `{json, #{<<"message">> => <<"TODO">>}}`
+- `create/1` returns `{status, 201, #{}, #{<<"message">> => <<"TODO">>}}`
+- `delete/1` returns `{status, 204}`
+
+If the file already exists, the command skips it with a warning.
+
+### `nova gen_router` — Generate a router module
+
+Scaffolds a router module implementing the `nova_router` behaviour with an empty routes list.
+
+```
+$ rebar3 nova gen_router --name api_v1 --prefix /api/v1
+===> Created src/myapp_api_v1_router.erl
+```
+
+**Options:**
+
+| Flag | Required | Default | Description |
+|------|----------|---------|-------------|
+| `--name`, `-n` | yes | — | Router name |
+| `--prefix`, `-p` | no | `""` | URL prefix for routes |
+
+### `nova gen_resource` — Generate a full resource
+
+Combines controller generation, JSON schema creation, and prints route snippets to add to your router.
+
+```
+$ rebar3 nova gen_resource --name products
+===> Created src/controllers/myapp_products_controller.erl
+===> Created priv/schemas/product.json
+===>
+===> Add these routes to your router:
+===>   {<<"/products">>, {myapp_products_controller, list}, #{methods => [get]}}
+===>   {<<"/products/:id">>, {myapp_products_controller, show}, #{methods => [get]}}
+===>   {<<"/products">>, {myapp_products_controller, create}, #{methods => [post]}}
+===>   {<<"/products/:id">>, {myapp_products_controller, update}, #{methods => [put]}}
+===>   {<<"/products/:id">>, {myapp_products_controller, delete}, #{methods => [delete]}}
+```
+
+**Options:** Same as `gen_controller`.
+
+The JSON schema is placed in `priv/schemas/{singular}.json` with `id` and `name` fields as a starting point. The resource name is naively singularized by stripping a trailing "s".
+
+### `nova gen_test` — Generate a Common Test suite
+
+Scaffolds a CT suite with test cases for CRUD actions using `httpc`.
+
+```
+$ rebar3 nova gen_test --name users
+===> Created test/myapp_users_controller_SUITE.erl
+```
+
+**Options:**
+
+| Flag | Required | Default | Description |
+|------|----------|---------|-------------|
+| `--name`, `-n` | yes | — | Resource name |
+
+The generated suite starts `inets` and the application in `init_per_suite`, then tests each CRUD endpoint against `http://localhost:8080/{name}`.
+
+### `nova openapi` — Generate OpenAPI 3.0.3 spec
+
+Generates an OpenAPI 3.0.3 JSON specification from compiled routes and any JSON schemas found in `priv/schemas/`.
+
+```
+$ rebar3 nova openapi
+===> OpenAPI spec written to openapi.json
+===> Swagger UI written to swagger.html
+
+$ rebar3 nova openapi --output priv/assets/openapi.json --title "My API" --api-version 1.0.0
+```
+
+**Options:**
+
+| Flag | Required | Default | Description |
+|------|----------|---------|-------------|
+| `--output`, `-o` | no | `openapi.json` | Output file path |
+| `--title`, `-t` | no | app name | API title |
+| `--api-version`, `-v` | no | `0.1.0` | API version string |
+
+A `swagger.html` file is also generated alongside the spec for quick browser-based exploration.
+
+### `nova middleware` — Show plugin/middleware chains
+
+Displays global plugins and per-route-group plugin chains, preserving the grouping defined in your router's `routes/1` function.
+
+```
+$ rebar3 nova middleware
+
+=== Global Plugins ===
+  (none)
+
+=== Route Groups (myapp_router) ===
+
+  Group: prefix=/  security=false
+  Plugins:
+    (inherits global: none)
+  Routes:
+    GET /heartbeat -> myapp_health_controller:heartbeat
+    GET /health -> myapp_health_controller:health
+
+  Group: prefix=/api  security=fun myapp_auth:validate_token/1
+  Plugins:
+    pre_request: nova_cors_plugin #{allow_origins => <<"*">>}
+    pre_request: nova_request_logger #{level => info}
+  Routes:
+    GET /users -> myapp_users_controller:list
+    POST /users -> myapp_users_controller:create
+```
+
+Groups that don't specify their own `plugins` key inherit from the global Nova plugin configuration.
+
+### `nova config` — Show Nova configuration
+
+Displays all Nova configuration keys read from `sys.config`, showing current values or `(default)` when using built-in defaults.
+
+```
+$ rebar3 nova config
+
+=== Nova Configuration ===
+
+  bootstrap_application     myapp
+  environment               dev
+  cowboy_configuration       #{port => 8080} (default)
+  plugins                   [] (default)
+  json_lib                  thoas (default)
+  use_stacktrace            false (default)
+  dispatch_backend          persistent_term (default)
+```
+
+Warns if `bootstrap_application` is not set.
+
+### `nova audit` — Audit route security
+
+Checks compiled routes for common security issues and prints findings grouped by severity.
+
+```
+$ rebar3 nova audit
+
+=== Security Audit ===
+
+  WARNINGS:
+    POST /users (myapp_users_controller) has no security
+    PUT /users/1 (myapp_users_controller) has no security
+    DELETE /users/1 (myapp_users_controller) has no security
+
+  INFO:
+    GET /users (myapp_users_controller) has no security
+    GET /health (myapp_health_controller) has no security
+
+  Summary: 3 warning(s), 2 info(s)
+```
+
+**Rules checked:**
+- **Warning**: Mutation methods (POST, PUT, DELETE, PATCH) without a security callback
+- **Warning**: Wildcard method (`'_'`) matching all HTTP methods on a route
+- **Info**: GET routes without a security callback
+
+### `nova release` — Build a release
+
+Wraps the standard rebar3 release provider. If `priv/schemas/` exists, regenerates the OpenAPI spec before building.
+
+```
+$ rebar3 nova release
+===> Regenerating OpenAPI spec...
+===> Release built successfully with profile 'prod'
+
+$ rebar3 nova release --profile staging
+```
+
+**Options:**
+
+| Flag | Required | Default | Description |
+|------|----------|---------|-------------|
+| `--profile`, `-p` | no | `prod` | Release profile to use |

--- a/src/rebar3_nova.erl
+++ b/src/rebar3_nova.erl
@@ -8,10 +8,18 @@ init(State) ->
     case parse_version(Vsn) of
         [Major, Minor| _Patch] when Major >= "3" andalso
                                    Minor > "15" ->
-            lists:foldl(fun provider_init/2, {ok, State}, [rebar3_nova_prv, rebar3_nova_serve, rebar3_nova_routes]);
+            lists:foldl(fun provider_init/2, {ok, State},
+                        [rebar3_nova_prv, rebar3_nova_serve, rebar3_nova_routes, rebar3_nova_openapi,
+                         rebar3_nova_gen_controller, rebar3_nova_gen_router, rebar3_nova_gen_resource,
+                         rebar3_nova_gen_test, rebar3_nova_middleware, rebar3_nova_config,
+                         rebar3_nova_audit, rebar3_nova_release]);
         ["git"] ->
             rebar_api:info("Compiling with rebar3 from git - make sure you know what you are doing"),
-            lists:foldl(fun provider_init/2, {ok, State}, [rebar3_nova_prv, rebar3_nova_serve, rebar3_nova_routes]);
+            lists:foldl(fun provider_init/2, {ok, State},
+                        [rebar3_nova_prv, rebar3_nova_serve, rebar3_nova_routes, rebar3_nova_openapi,
+                         rebar3_nova_gen_controller, rebar3_nova_gen_router, rebar3_nova_gen_resource,
+                         rebar3_nova_gen_test, rebar3_nova_middleware, rebar3_nova_config,
+                         rebar3_nova_audit, rebar3_nova_release]);
         SomethingElse ->
             rebar_api:abort("Nova needs Rebar > 3.15 to function. Your version is: ~p. Please consider upgrading.", [SomethingElse])
     end.

--- a/src/rebar3_nova_audit.erl
+++ b/src/rebar3_nova_audit.erl
@@ -1,0 +1,135 @@
+-module(rebar3_nova_audit).
+
+-export([init/1, do/1, format_error/1]).
+
+-include("nova_router.hrl").
+-include_lib("routing_tree/include/routing_tree.hrl").
+
+-define(PROVIDER, audit).
+-define(DEPS, [{default, compile}]).
+
+-spec init(rebar_state:t()) -> {ok, rebar_state:t()}.
+init(State) ->
+    Provider = providers:create([
+            {name, ?PROVIDER},
+            {module, ?MODULE},
+            {namespace, nova},
+            {bare, true},
+            {deps, ?DEPS},
+            {example, "rebar3 nova audit"},
+            {opts, []},
+            {short_desc, "Audit route security configuration"},
+            {desc, "Checks routes for security issues like unsecured mutations and wildcard methods"}
+    ]),
+    {ok, rebar_state:add_provider(State, Provider)}.
+
+-spec do(rebar_state:t()) -> {ok, rebar_state:t()} | {error, string()}.
+do(State) ->
+    AppName = rebar3_nova_utils:get_app_name(State),
+    Dispatch = nova_router:compile([AppName]),
+    Routes = collect_routes(Dispatch),
+
+    {Warnings, Infos} = classify_findings(Routes),
+
+    io:format("~n=== Security Audit ===~n"),
+
+    case Warnings of
+        [] -> ok;
+        _ ->
+            io:format("~n  WARNINGS:~n"),
+            lists:foreach(fun(W) -> io:format("    ~s~n", [W]) end, Warnings)
+    end,
+
+    case Infos of
+        [] -> ok;
+        _ ->
+            io:format("~n  INFO:~n"),
+            lists:foreach(fun(I) -> io:format("    ~s~n", [I]) end, Infos)
+    end,
+
+    io:format("~n  Summary: ~b warning(s), ~b info(s)~n",
+              [length(Warnings), length(Infos)]),
+    {ok, State}.
+
+-spec format_error(any()) -> iolist().
+format_error(Reason) ->
+    io_lib:format("~p", [Reason]).
+
+classify_findings(Routes) ->
+    lists:foldl(fun({Path, Method, Secure, Module, IsWildcard}, {WAcc, IAcc}) ->
+        MethodStr = string:uppercase(erlang:binary_to_list(Method)),
+        W1 = case is_mutation(Method) andalso Secure =:= false of
+            true ->
+                [io_lib:format("~s ~s (~s) has no security", [MethodStr, Path, Module]) | WAcc];
+            false ->
+                WAcc
+        end,
+        W2 = case IsWildcard of
+            true ->
+                [io_lib:format("Wildcard method on ~s (~s) - all HTTP methods accepted", [Path, Module]) | W1];
+            false ->
+                W1
+        end,
+        I1 = case Method =:= <<"get">> andalso Secure =:= false of
+            true ->
+                [io_lib:format("GET ~s (~s) has no security", [Path, Module]) | IAcc];
+            false ->
+                IAcc
+        end,
+        {W2, I1}
+    end, {[], []}, Routes).
+
+is_mutation(<<"post">>) -> true;
+is_mutation(<<"put">>) -> true;
+is_mutation(<<"delete">>) -> true;
+is_mutation(<<"patch">>) -> true;
+is_mutation(_) -> false.
+
+collect_routes(#host_tree{hosts = Hosts}) ->
+    lists:flatmap(fun({_Host, #routing_tree{tree = Tree}}) ->
+        collect_nodes(Tree, <<>>)
+    end, Hosts).
+
+collect_nodes([], _Prefix) -> [];
+collect_nodes([#node{is_wildcard = true}|Tl], Prefix) ->
+    collect_nodes(Tl, Prefix);
+collect_nodes([#node{segment = Segment}|Tl], Prefix) when is_integer(Segment) ->
+    collect_nodes(Tl, Prefix);
+collect_nodes([#node{segment = Segment, is_binding = IsBinding, value = Value, children = Children}|Tl], Prefix) ->
+    SegBin = segment_to_binary(Segment, IsBinding),
+    NewPrefix = <<Prefix/binary, "/", SegBin/binary>>,
+    HandlerRoutes = lists:filtermap(fun(NodeComp) -> classify_handler(NodeComp, NewPrefix) end, Value),
+    lists:flatten(HandlerRoutes) ++ collect_nodes(Children, NewPrefix) ++ collect_nodes(Tl, Prefix).
+
+segment_to_binary(Segment, true) when is_binary(Segment) ->
+    <<"{", Segment/binary, "}">>;
+segment_to_binary(Segment, _) when is_binary(Segment) ->
+    Segment;
+segment_to_binary(Segment, IsBinding) when is_list(Segment) ->
+    segment_to_binary(erlang:list_to_binary(Segment), IsBinding).
+
+classify_handler(#node_comp{value = #nova_handler_value{module = nova_file_controller}}, _Path) ->
+    false;
+classify_handler(#node_comp{value = #nova_handler_value{module = nova_error_controller}}, _Path) ->
+    false;
+classify_handler(#node_comp{comparator = Method,
+                            value = #nova_handler_value{module = undefined, function = undefined,
+                                                        callback = Callback, secure = Secure}}, Path) ->
+    {module, Module} = lists:keyfind(module, 1, erlang:fun_info(Callback)),
+    expand_methods(Method, Path, Module, Secure);
+classify_handler(#node_comp{comparator = Method,
+                            value = #nova_handler_value{module = Module, secure = Secure}}, Path) ->
+    expand_methods(Method, Path, Module, Secure);
+classify_handler(#node_comp{value = #cowboy_handler_value{}}, _Path) ->
+    false.
+
+expand_methods('_', Path, Module, Secure) ->
+    Methods = [<<"get">>, <<"post">>, <<"put">>, <<"delete">>, <<"patch">>],
+    {true, [{Path, M, Secure, Module, true} || M <- Methods]};
+expand_methods(Method, Path, Module, Secure) ->
+    {true, [{Path, method_to_binary(Method), Secure, Module, false}]}.
+
+method_to_binary(Method) when is_atom(Method) ->
+    erlang:atom_to_binary(Method);
+method_to_binary(Method) when is_binary(Method) ->
+    string:lowercase(Method).

--- a/src/rebar3_nova_config.erl
+++ b/src/rebar3_nova_config.erl
@@ -1,0 +1,61 @@
+-module(rebar3_nova_config).
+
+-export([init/1, do/1, format_error/1]).
+
+-define(PROVIDER, config).
+-define(DEPS, [{default, compile}]).
+
+-spec init(rebar_state:t()) -> {ok, rebar_state:t()}.
+init(State) ->
+    Provider = providers:create([
+            {name, ?PROVIDER},
+            {module, ?MODULE},
+            {namespace, nova},
+            {bare, true},
+            {deps, ?DEPS},
+            {example, "rebar3 nova config"},
+            {opts, []},
+            {short_desc, "Show Nova application configuration"},
+            {desc, "Displays all Nova configuration keys with their values or defaults"}
+    ]),
+    {ok, rebar_state:add_provider(State, Provider)}.
+
+-spec do(rebar_state:t()) -> {ok, rebar_state:t()} | {error, string()}.
+do(State) ->
+    Config = rebar3_nova_utils:load_sys_config(State),
+    NovaConfig = proplists:get_value(nova, Config, []),
+
+    io:format("~n=== Nova Configuration ===~n~n"),
+
+    Defaults = [
+        {bootstrap_application, required},
+        {environment, dev},
+        {cowboy_configuration, #{port => 8080}},
+        {plugins, []},
+        {json_lib, thoas},
+        {use_stacktrace, false},
+        {dispatch_backend, persistent_term}
+    ],
+
+    lists:foreach(fun({Key, Default}) ->
+        case proplists:get_value(Key, NovaConfig) of
+            undefined when Default =:= required ->
+                io:format("  ~-25s *** MISSING (required) ***~n", [atom_to_list(Key)]);
+            undefined ->
+                io:format("  ~-25s ~p (default)~n", [atom_to_list(Key), Default]);
+            Value ->
+                io:format("  ~-25s ~p~n", [atom_to_list(Key), Value])
+        end
+    end, Defaults),
+
+    case proplists:get_value(bootstrap_application, NovaConfig) of
+        undefined ->
+            rebar_api:warn("~nbootstrap_application is not set in Nova config!", []);
+        _ ->
+            ok
+    end,
+    {ok, State}.
+
+-spec format_error(any()) -> iolist().
+format_error(Reason) ->
+    io_lib:format("~p", [Reason]).

--- a/src/rebar3_nova_gen_controller.erl
+++ b/src/rebar3_nova_gen_controller.erl
@@ -1,0 +1,83 @@
+-module(rebar3_nova_gen_controller).
+
+-export([init/1, do/1, format_error/1]).
+-export([generate/4]).
+
+-define(PROVIDER, gen_controller).
+-define(DEPS, [{default, compile}]).
+
+-spec init(rebar_state:t()) -> {ok, rebar_state:t()}.
+init(State) ->
+    Provider = providers:create([
+            {name, ?PROVIDER},
+            {module, ?MODULE},
+            {namespace, nova},
+            {bare, true},
+            {deps, ?DEPS},
+            {example, "rebar3 nova gen_controller --name users"},
+            {opts, [
+                {name, $n, "name", string, "Controller name (required)"},
+                {actions, $a, "actions", {string, "list,show,create,update,delete"}, "Comma-separated actions"}
+            ]},
+            {short_desc, "Generate a Nova controller"},
+            {desc, "Generates a controller module with stub action functions"}
+    ]),
+    {ok, rebar_state:add_provider(State, Provider)}.
+
+-spec do(rebar_state:t()) -> {ok, rebar_state:t()} | {error, string()}.
+do(State) ->
+    {Args, _} = rebar_state:command_parsed_args(State),
+    case proplists:get_value(name, Args) of
+        undefined ->
+            rebar_api:abort("--name is required", []);
+        Name ->
+            AppName = rebar3_nova_utils:get_app_name(State),
+            AppDir = rebar3_nova_utils:get_app_dir(State),
+            ActionsStr = proplists:get_value(actions, Args, "list,show,create,update,delete"),
+            Actions = rebar3_nova_utils:parse_actions(ActionsStr),
+            generate(AppName, AppDir, Name, Actions),
+            {ok, State}
+    end.
+
+-spec format_error(any()) -> iolist().
+format_error(Reason) ->
+    io_lib:format("~p", [Reason]).
+
+-spec generate(atom(), file:filename(), string(), [atom()]) -> ok | skipped.
+generate(AppName, AppDir, Name, Actions) ->
+    ModName = io_lib:format("~s_~s_controller", [AppName, Name]),
+    FileName = filename:join([AppDir, "src", "controllers", ModName ++ ".erl"]),
+    Content = generate_content(erlang:list_to_atom(lists:flatten(ModName)), Actions),
+    rebar3_nova_utils:write_file_if_not_exists(FileName, Content).
+
+generate_content(ModName, Actions) ->
+    Header = io_lib:format(
+        "-module(~s).~n~n"
+        "-export([~s]).~n~n",
+        [ModName, format_exports(Actions)]),
+    Functions = lists:map(fun(Action) -> generate_function(Action) end, Actions),
+    iolist_to_binary([Header | Functions]).
+
+format_exports(Actions) ->
+    string:join([io_lib:format("~s/1", [A]) || A <- Actions], ", ").
+
+generate_function(list) ->
+    "list(#{req := _Req} = _NovaReq) ->\n"
+    "    {json, #{<<\"message\">> => <<\"TODO\">>}}.\n\n";
+generate_function(show) ->
+    "show(#{req := _Req} = _NovaReq) ->\n"
+    "    {json, #{<<\"message\">> => <<\"TODO\">>}}.\n\n";
+generate_function(create) ->
+    "create(#{req := _Req} = _NovaReq) ->\n"
+    "    {status, 201, #{}, #{<<\"message\">> => <<\"TODO\">>}}.\n\n";
+generate_function(update) ->
+    "update(#{req := _Req} = _NovaReq) ->\n"
+    "    {json, #{<<\"message\">> => <<\"TODO\">>}}.\n\n";
+generate_function(delete) ->
+    "delete(#{req := _Req} = _NovaReq) ->\n"
+    "    {status, 204}.\n\n";
+generate_function(Action) ->
+    io_lib:format(
+        "~s(#{req := _Req} = _NovaReq) ->~n"
+        "    {json, #{<<\"message\">> => <<\"TODO\">>}}.~n~n",
+        [Action]).

--- a/src/rebar3_nova_gen_resource.erl
+++ b/src/rebar3_nova_gen_resource.erl
@@ -1,0 +1,83 @@
+-module(rebar3_nova_gen_resource).
+
+-export([init/1, do/1, format_error/1]).
+
+-define(PROVIDER, gen_resource).
+-define(DEPS, [{default, compile}]).
+
+-spec init(rebar_state:t()) -> {ok, rebar_state:t()}.
+init(State) ->
+    Provider = providers:create([
+            {name, ?PROVIDER},
+            {module, ?MODULE},
+            {namespace, nova},
+            {bare, true},
+            {deps, ?DEPS},
+            {example, "rebar3 nova gen_resource --name users"},
+            {opts, [
+                {name, $n, "name", string, "Resource name (required)"},
+                {actions, $a, "actions", {string, "list,show,create,update,delete"}, "Comma-separated actions"}
+            ]},
+            {short_desc, "Generate controller, schema, and route hints"},
+            {desc, "Generates a controller, JSON schema, and prints route snippets to add to your router"}
+    ]),
+    {ok, rebar_state:add_provider(State, Provider)}.
+
+-spec do(rebar_state:t()) -> {ok, rebar_state:t()} | {error, string()}.
+do(State) ->
+    {Args, _} = rebar_state:command_parsed_args(State),
+    case proplists:get_value(name, Args) of
+        undefined ->
+            rebar_api:abort("--name is required", []);
+        Name ->
+            AppName = rebar3_nova_utils:get_app_name(State),
+            AppDir = rebar3_nova_utils:get_app_dir(State),
+            ActionsStr = proplists:get_value(actions, Args, "list,show,create,update,delete"),
+            Actions = rebar3_nova_utils:parse_actions(ActionsStr),
+            rebar3_nova_gen_controller:generate(AppName, AppDir, Name, Actions),
+            generate_schema(AppDir, Name),
+            print_route_hints(AppName, Name, Actions),
+            {ok, State}
+    end.
+
+-spec format_error(any()) -> iolist().
+format_error(Reason) ->
+    io_lib:format("~p", [Reason]).
+
+generate_schema(AppDir, Name) ->
+    Singular = singularize(Name),
+    SchemaFile = filename:join([AppDir, "priv", "schemas", Singular ++ ".json"]),
+    Schema = #{
+        <<"$schema">> => <<"http://json-schema.org/draft-07/schema#">>,
+        <<"type">> => <<"object">>,
+        <<"properties">> => #{
+            <<"id">> => #{<<"type">> => <<"integer">>},
+            <<"name">> => #{<<"type">> => <<"string">>}
+        },
+        <<"required">> => [<<"id">>, <<"name">>]
+    },
+    Json = thoas:encode(Schema),
+    rebar3_nova_utils:write_file_if_not_exists(SchemaFile, Json).
+
+print_route_hints(AppName, Name, Actions) ->
+    Controller = io_lib:format("~s_~s_controller", [AppName, Name]),
+    rebar_api:info("~nAdd these routes to your router:~n", []),
+    lists:foreach(fun(list) ->
+        rebar_api:info("  {<<\"/~s\">>, {~s, list}, #{methods => [get]}}", [Name, Controller]);
+    (show) ->
+        rebar_api:info("  {<<\"/~s/:id\">>, {~s, show}, #{methods => [get]}}", [Name, Controller]);
+    (create) ->
+        rebar_api:info("  {<<\"/~s\">>, {~s, create}, #{methods => [post]}}", [Name, Controller]);
+    (update) ->
+        rebar_api:info("  {<<\"/~s/:id\">>, {~s, update}, #{methods => [put]}}", [Name, Controller]);
+    (delete) ->
+        rebar_api:info("  {<<\"/~s/:id\">>, {~s, delete}, #{methods => [delete]}}", [Name, Controller]);
+    (_) ->
+        ok
+    end, Actions).
+
+singularize(Name) ->
+    case lists:reverse(Name) of
+        [$s | Rest] -> lists:reverse(Rest);
+        _ -> Name
+    end.

--- a/src/rebar3_nova_gen_router.erl
+++ b/src/rebar3_nova_gen_router.erl
@@ -1,0 +1,59 @@
+-module(rebar3_nova_gen_router).
+
+-export([init/1, do/1, format_error/1]).
+
+-define(PROVIDER, gen_router).
+-define(DEPS, [{default, compile}]).
+
+-spec init(rebar_state:t()) -> {ok, rebar_state:t()}.
+init(State) ->
+    Provider = providers:create([
+            {name, ?PROVIDER},
+            {module, ?MODULE},
+            {namespace, nova},
+            {bare, true},
+            {deps, ?DEPS},
+            {example, "rebar3 nova gen_router --name api_v1 --prefix /api/v1"},
+            {opts, [
+                {name, $n, "name", string, "Router name (required)"},
+                {prefix, $p, "prefix", {string, ""}, "URL prefix for routes"}
+            ]},
+            {short_desc, "Generate a Nova router module"},
+            {desc, "Generates a router module implementing the nova_router behaviour"}
+    ]),
+    {ok, rebar_state:add_provider(State, Provider)}.
+
+-spec do(rebar_state:t()) -> {ok, rebar_state:t()} | {error, string()}.
+do(State) ->
+    {Args, _} = rebar_state:command_parsed_args(State),
+    case proplists:get_value(name, Args) of
+        undefined ->
+            rebar_api:abort("--name is required", []);
+        Name ->
+            AppName = rebar3_nova_utils:get_app_name(State),
+            AppDir = rebar3_nova_utils:get_app_dir(State),
+            Prefix = proplists:get_value(prefix, Args, ""),
+            generate(AppName, AppDir, Name, Prefix),
+            {ok, State}
+    end.
+
+-spec format_error(any()) -> iolist().
+format_error(Reason) ->
+    io_lib:format("~p", [Reason]).
+
+generate(AppName, AppDir, Name, Prefix) ->
+    ModName = io_lib:format("~s_~s_router", [AppName, Name]),
+    FileName = filename:join([AppDir, "src", lists:flatten(ModName) ++ ".erl"]),
+    Content = generate_content(lists:flatten(ModName), Prefix),
+    rebar3_nova_utils:write_file_if_not_exists(FileName, Content).
+
+generate_content(ModName, Prefix) ->
+    iolist_to_binary(io_lib:format(
+        "-module(~s).~n"
+        "-behaviour(nova_router).~n~n"
+        "-export([routes/0, prefix/0]).~n~n"
+        "prefix() ->~n"
+        "    \"~s\".~n~n"
+        "routes() ->~n"
+        "    [].~n",
+        [ModName, Prefix])).

--- a/src/rebar3_nova_gen_test.erl
+++ b/src/rebar3_nova_gen_test.erl
@@ -1,0 +1,73 @@
+-module(rebar3_nova_gen_test).
+
+-export([init/1, do/1, format_error/1]).
+
+-define(PROVIDER, gen_test).
+-define(DEPS, [{default, compile}]).
+
+-spec init(rebar_state:t()) -> {ok, rebar_state:t()}.
+init(State) ->
+    Provider = providers:create([
+            {name, ?PROVIDER},
+            {module, ?MODULE},
+            {namespace, nova},
+            {bare, true},
+            {deps, ?DEPS},
+            {example, "rebar3 nova gen_test --name users"},
+            {opts, [
+                {name, $n, "name", string, "Resource name (required)"}
+            ]},
+            {short_desc, "Generate a Common Test suite for a controller"},
+            {desc, "Generates a CT suite with test cases for CRUD actions"}
+    ]),
+    {ok, rebar_state:add_provider(State, Provider)}.
+
+-spec do(rebar_state:t()) -> {ok, rebar_state:t()} | {error, string()}.
+do(State) ->
+    {Args, _} = rebar_state:command_parsed_args(State),
+    case proplists:get_value(name, Args) of
+        undefined ->
+            rebar_api:abort("--name is required", []);
+        Name ->
+            AppName = rebar3_nova_utils:get_app_name(State),
+            AppDir = rebar3_nova_utils:get_app_dir(State),
+            generate(AppName, AppDir, Name),
+            {ok, State}
+    end.
+
+-spec format_error(any()) -> iolist().
+format_error(Reason) ->
+    io_lib:format("~p", [Reason]).
+
+generate(AppName, AppDir, Name) ->
+    SuiteName = io_lib:format("~s_~s_controller_SUITE", [AppName, Name]),
+    FileName = filename:join([AppDir, "test", lists:flatten(SuiteName) ++ ".erl"]),
+    Content = generate_content(lists:flatten(SuiteName), AppName, Name),
+    rebar3_nova_utils:write_file_if_not_exists(FileName, Content).
+
+generate_content(SuiteName, AppName, Name) ->
+    iolist_to_binary(io_lib:format(
+        "-module(~s).~n"
+        "-include_lib(\"common_test/include/ct.hrl\").~n~n"
+        "-export([all/0, init_per_suite/1, end_per_suite/1]).~n"
+        "-export([test_list/1, test_show/1, test_create/1, test_update/1, test_delete/1]).~n~n"
+        "all() ->~n"
+        "    [test_list, test_show, test_create, test_update, test_delete].~n~n"
+        "init_per_suite(Config) ->~n"
+        "    application:ensure_all_started(inets),~n"
+        "    application:ensure_all_started(~s),~n"
+        "    Config.~n~n"
+        "end_per_suite(_Config) ->~n"
+        "    application:stop(~s),~n"
+        "    ok.~n~n"
+        "test_list(_Config) ->~n"
+        "    {ok, {{_, 200, _}, _, _}} = httpc:request(\"http://localhost:8080/~s\").~n~n"
+        "test_show(_Config) ->~n"
+        "    {ok, {{_, 200, _}, _, _}} = httpc:request(\"http://localhost:8080/~s/1\").~n~n"
+        "test_create(_Config) ->~n"
+        "    {ok, {{_, 201, _}, _, _}} = httpc:request(post, {\"http://localhost:8080/~s\", [], \"application/json\", \"{}\"}, [], []).~n~n"
+        "test_update(_Config) ->~n"
+        "    {ok, {{_, 200, _}, _, _}} = httpc:request(put, {\"http://localhost:8080/~s/1\", [], \"application/json\", \"{}\"}, [], []).~n~n"
+        "test_delete(_Config) ->~n"
+        "    {ok, {{_, 204, _}, _, _}} = httpc:request(delete, {\"http://localhost:8080/~s/1\", []}, [], []).~n",
+        [SuiteName, AppName, AppName, Name, Name, Name, Name, Name])).

--- a/src/rebar3_nova_middleware.erl
+++ b/src/rebar3_nova_middleware.erl
@@ -1,0 +1,111 @@
+-module(rebar3_nova_middleware).
+
+-export([init/1, do/1, format_error/1]).
+
+-define(PROVIDER, middleware).
+-define(DEPS, [{default, compile}]).
+
+-spec init(rebar_state:t()) -> {ok, rebar_state:t()}.
+init(State) ->
+    Provider = providers:create([
+            {name, ?PROVIDER},
+            {module, ?MODULE},
+            {namespace, nova},
+            {bare, true},
+            {deps, ?DEPS},
+            {example, "rebar3 nova middleware"},
+            {opts, []},
+            {short_desc, "Show middleware/plugin chain for all routes"},
+            {desc, "Lists global and per-route-group plugins configured for the Nova application"}
+    ]),
+    {ok, rebar_state:add_provider(State, Provider)}.
+
+-spec do(rebar_state:t()) -> {ok, rebar_state:t()} | {error, string()}.
+do(State) ->
+    AppName = rebar3_nova_utils:get_app_name(State),
+    Config = rebar3_nova_utils:load_sys_config(State),
+    NovaConfig = proplists:get_value(nova, Config, []),
+    GlobalPlugins = proplists:get_value(plugins, NovaConfig, []),
+    Env = proplists:get_value(environment, NovaConfig, dev),
+
+    io:format("~n=== Global Plugins ===~n"),
+    print_plugins(GlobalPlugins, "  "),
+
+    Router = erlang:list_to_atom(lists:flatten(io_lib:format("~s_router", [AppName]))),
+    Groups = get_routes(Router, Env),
+
+    io:format("~n=== Route Groups (~s) ===~n", [Router]),
+    print_groups(Groups, GlobalPlugins),
+    {ok, State}.
+
+-spec format_error(any()) -> iolist().
+format_error(Reason) ->
+    io_lib:format("~p", [Reason]).
+
+get_routes(Router, Env) ->
+    code:ensure_loaded(Router),
+    case erlang:function_exported(Router, routes, 1) of
+        true -> Router:routes(Env);
+        false -> Router:routes()
+    end.
+
+print_groups(Groups, GlobalPlugins) ->
+    lists:foreach(fun(Group) ->
+        Prefix = maps:get(prefix, Group, ""),
+        Security = maps:get(security, Group, false),
+        Routes = maps:get(routes, Group, []),
+
+        PrefixDisplay = case Prefix of
+            "" -> "/";
+            P -> P
+        end,
+        io:format("~n  Group: prefix=~s  security=~p~n", [PrefixDisplay, Security]),
+
+        io:format("  Plugins:~n"),
+        case maps:is_key(plugins, Group) of
+            true ->
+                case maps:get(plugins, Group) of
+                    [] -> io:format("    (none)~n");
+                    Plugins -> print_plugins(Plugins, "    ")
+                end;
+            false when GlobalPlugins =:= [] ->
+                io:format("    (inherits global: none)~n");
+            false ->
+                io:format("    (inherits global)~n"),
+                print_plugins(GlobalPlugins, "    ")
+        end,
+
+        io:format("  Routes:~n"),
+        lists:foreach(fun(Route) -> print_route(Route) end, Routes)
+    end, Groups).
+
+print_route({Path, Handler, Opts}) ->
+    Methods = maps:get(methods, Opts, ['_']),
+    HandlerStr = format_handler(Handler),
+    MethodsStr = format_methods(Methods),
+    io:format("    ~s ~s -> ~s~n", [MethodsStr, Path, HandlerStr]);
+print_route({Path, Handler}) ->
+    HandlerStr = format_handler(Handler),
+    io:format("    ALL ~s -> ~s~n", [Path, HandlerStr]).
+
+format_handler(Fun) when is_function(Fun) ->
+    {module, Mod} = lists:keyfind(module, 1, erlang:fun_info(Fun)),
+    {name, Name} = lists:keyfind(name, 1, erlang:fun_info(Fun)),
+    io_lib:format("~s:~s", [Mod, Name]);
+format_handler({Mod, Fun}) ->
+    io_lib:format("~s:~s", [Mod, Fun]).
+
+format_methods(Methods) ->
+    string:join([string:uppercase(erlang:atom_to_list(M)) || M <- Methods], ",").
+
+print_plugins([], _Indent) ->
+    io:format("~s(none)~n", [_Indent]);
+print_plugins(Plugins, Indent) ->
+    lists:foreach(fun
+        ({Type, Plugin, Opts}) ->
+            io:format("~s~s: ~s ~p~n", [Indent, Type, Plugin, Opts]);
+        ({Type, Plugin}) ->
+            io:format("~s~s: ~s~n", [Indent, Type, Plugin]);
+        (Other) ->
+            io:format("~s~p~n", [Indent, Other])
+    end, Plugins).

--- a/src/rebar3_nova_openapi.erl
+++ b/src/rebar3_nova_openapi.erl
@@ -1,0 +1,234 @@
+-module(rebar3_nova_openapi).
+
+-export([init/1, do/1, format_error/1]).
+
+-include("nova_router.hrl").
+-include_lib("routing_tree/include/routing_tree.hrl").
+
+-define(PROVIDER, openapi).
+-define(DEPS, [{default, compile}]).
+
+%% ===================================================================
+%% Public API
+%% ===================================================================
+-spec init(rebar_state:t()) -> {ok, rebar_state:t()}.
+init(State) ->
+    Provider = providers:create([
+            {name, ?PROVIDER},
+            {module, ?MODULE},
+            {namespace, nova},
+            {bare, true},
+            {deps, ?DEPS},
+            {example, "rebar3 nova openapi"},
+            {opts, [
+                {output, $o, "output", {string, "openapi.json"}, "Output file path"},
+                {title, $t, "title", string, "API title (default: app name)"},
+                {api_version, $v, "api-version", {string, "0.1.0"}, "API version"}
+            ]},
+            {short_desc, "Generate OpenAPI 3.0.3 spec from routes"},
+            {desc, "Generates an OpenAPI 3.0.3 JSON specification from compiled Nova routes"}
+    ]),
+    {ok, rebar_state:add_provider(State, Provider)}.
+
+-spec do(rebar_state:t()) -> {ok, rebar_state:t()} | {error, string()}.
+do(State) ->
+    [Hd|_] = rebar_state:project_apps(State),
+    AppName = erlang:binary_to_atom(rebar_app_info:name(Hd)),
+    AppDir = rebar_app_info:dir(Hd),
+
+    {Args, _} = rebar_state:command_parsed_args(State),
+    Output = proplists:get_value(output, Args, "openapi.json"),
+    Title = case proplists:get_value(title, Args) of
+                undefined -> erlang:atom_to_list(AppName);
+                T -> T
+            end,
+    ApiVersion = proplists:get_value(api_version, Args, "0.1.0"),
+
+    Dispatch = nova_router:compile([AppName]),
+    Routes = collect_routes(Dispatch),
+
+    Schemas = load_schemas(AppDir),
+
+    Spec = build_spec(Title, ApiVersion, Routes, Schemas),
+    Json = thoas:encode(Spec),
+
+    ok = file:write_file(Output, Json),
+    rebar_api:info("OpenAPI spec written to ~s", [Output]),
+
+    SwaggerPath = filename:join(filename:dirname(Output), "swagger.html"),
+    ok = file:write_file(SwaggerPath, swagger_html(Output)),
+    rebar_api:info("Swagger UI written to ~s", [SwaggerPath]),
+    {ok, State}.
+
+-spec format_error(any()) -> iolist().
+format_error(Reason) ->
+    io_lib:format("~p", [Reason]).
+
+%% ===================================================================
+%% Route collection
+%% ===================================================================
+collect_routes(#host_tree{hosts = Hosts}) ->
+    lists:flatmap(fun({_Host, #routing_tree{tree = Tree}}) ->
+        collect_nodes(Tree, <<>>)
+    end, Hosts).
+
+collect_nodes([], _Prefix) -> [];
+collect_nodes([#node{is_wildcard = true}|Tl], Prefix) ->
+    collect_nodes(Tl, Prefix);
+collect_nodes([#node{segment = Segment}|Tl], Prefix) when is_integer(Segment) ->
+    collect_nodes(Tl, Prefix);
+collect_nodes([#node{segment = Segment, is_binding = IsBinding, value = Value, children = Children}|Tl], Prefix) ->
+    SegBin = segment_to_binary(Segment, IsBinding),
+    NewPrefix = <<Prefix/binary, "/", SegBin/binary>>,
+    HandlerRoutes = lists:filtermap(fun(NodeComp) -> classify_handler(NodeComp, NewPrefix) end, Value),
+    HandlerRoutes ++ collect_nodes(Children, NewPrefix) ++ collect_nodes(Tl, Prefix).
+
+segment_to_binary(Segment, true) when is_binary(Segment) ->
+    <<"{", Segment/binary, "}">>;
+segment_to_binary(Segment, _) when is_binary(Segment) ->
+    Segment;
+segment_to_binary(Segment, IsBinding) when is_list(Segment) ->
+    segment_to_binary(erlang:list_to_binary(Segment), IsBinding).
+
+%% ===================================================================
+%% Handler classification
+%% ===================================================================
+classify_handler(#node_comp{value = #nova_handler_value{module = nova_file_controller}}, _Path) ->
+    false;
+classify_handler(#node_comp{value = #nova_handler_value{module = nova_error_controller}}, _Path) ->
+    false;
+classify_handler(#node_comp{comparator = Method,
+                            value = #nova_handler_value{module = undefined, function = undefined, callback = Callback}}, Path) ->
+    {module, Module} = lists:keyfind(module, 1, erlang:fun_info(Callback)),
+    {name, Function} = lists:keyfind(name, 1, erlang:fun_info(Callback)),
+    expand_methods(Method, Path, Module, Function);
+classify_handler(#node_comp{comparator = Method,
+                            value = #nova_handler_value{module = Module, function = Function}}, Path) ->
+    expand_methods(Method, Path, Module, Function);
+classify_handler(#node_comp{value = #cowboy_handler_value{}}, _Path) ->
+    false.
+
+expand_methods('_', Path, Module, Function) ->
+    Methods = [<<"get">>, <<"post">>, <<"put">>, <<"delete">>, <<"patch">>],
+    {true, [{Path, M, Module, Function} || M <- Methods]};
+expand_methods(Method, Path, Module, Function) ->
+    {true, [{Path, method_to_binary(Method), Module, Function}]}.
+
+method_to_binary(Method) when is_atom(Method) ->
+    erlang:atom_to_binary(Method);
+method_to_binary(Method) when is_binary(Method) ->
+    string:lowercase(Method).
+
+%% ===================================================================
+%% Schema loading
+%% ===================================================================
+load_schemas(AppDir) ->
+    SchemaDir = filename:join([AppDir, "priv", "schemas"]),
+    SchemaDirStr = unicode:characters_to_list(SchemaDir),
+    case filelib:is_dir(SchemaDirStr) of
+        false -> #{};
+        true ->
+            Files = filelib:wildcard("*.json", SchemaDirStr),
+            maps:from_list(lists:filtermap(fun(File) ->
+                FullPath = filename:join(SchemaDir, File),
+                case file:read_file(FullPath) of
+                    {ok, Bin} ->
+                        case thoas:decode(Bin) of
+                            {ok, Decoded} ->
+                                Name = erlang:list_to_binary(filename:basename(File, ".json")),
+                                {true, {Name, Decoded}};
+                            {error, _} ->
+                                rebar_api:warn("Failed to parse schema: ~s", [File]),
+                                false
+                        end;
+                    {error, _} ->
+                        false
+                end
+            end, Files))
+    end.
+
+%% ===================================================================
+%% OpenAPI spec building
+%% ===================================================================
+build_spec(Title, Version, Routes, Schemas) ->
+    Paths = build_paths(Routes),
+    Spec = #{
+        <<"openapi">> => <<"3.0.3">>,
+        <<"info">> => #{
+            <<"title">> => erlang:list_to_binary(Title),
+            <<"version">> => erlang:list_to_binary(Version)
+        },
+        <<"paths">> => Paths
+    },
+    case maps:size(Schemas) of
+        0 -> Spec;
+        _ -> Spec#{<<"components">> => #{<<"schemas">> => Schemas}}
+    end.
+
+build_paths(Routes) ->
+    %% Routes is a list of [{Path, Method, Module, Function}] (some entries are nested lists from wildcard expansion)
+    FlatRoutes = lists:flatten(Routes),
+    %% Group by path
+    Grouped = lists:foldl(fun({Path, Method, Module, Function}, Acc) ->
+        PathMethods = maps:get(Path, Acc, #{}),
+        OpId = <<(erlang:atom_to_binary(Module))/binary, ".", (erlang:atom_to_binary(Function))/binary>>,
+        Params = extract_path_params(Path),
+        Operation = case Params of
+            [] ->
+                #{
+                    <<"operationId">> => OpId,
+                    <<"responses">> => #{<<"200">> => #{<<"description">> => <<"Successful response">>}}
+                };
+            _ ->
+                #{
+                    <<"operationId">> => OpId,
+                    <<"parameters">> => Params,
+                    <<"responses">> => #{<<"200">> => #{<<"description">> => <<"Successful response">>}}
+                }
+        end,
+        Acc#{Path => PathMethods#{Method => Operation}}
+    end, #{}, FlatRoutes),
+    Grouped.
+
+extract_path_params(Path) ->
+    Segments = binary:split(Path, <<"/">>, [global]),
+    lists:filtermap(fun(Segment) ->
+        case Segment of
+            <<"{", Rest/binary>> ->
+                Name = binary:part(Rest, 0, byte_size(Rest) - 1),
+                {true, #{
+                    <<"name">> => Name,
+                    <<"in">> => <<"path">>,
+                    <<"required">> => true,
+                    <<"schema">> => #{<<"type">> => <<"string">>}
+                }};
+            _ ->
+                false
+        end
+    end, Segments).
+
+%% ===================================================================
+%% Swagger UI HTML
+%% ===================================================================
+swagger_html(SpecPath) ->
+    SpecFile = filename:basename(SpecPath),
+    ["<!DOCTYPE html>\n"
+     "<html lang=\"en\">\n"
+     "<head>\n"
+     "  <meta charset=\"UTF-8\">\n"
+     "  <title>Swagger UI</title>\n"
+     "  <link rel=\"stylesheet\" href=\"https://unpkg.com/swagger-ui-dist@5/swagger-ui.css\">\n"
+     "</head>\n"
+     "<body>\n"
+     "  <div id=\"swagger-ui\"></div>\n"
+     "  <script src=\"https://unpkg.com/swagger-ui-dist@5/swagger-ui-bundle.js\"></script>\n"
+     "  <script>\n"
+     "    SwaggerUIBundle({\n"
+     "      url: '/", SpecFile, "',\n"
+     "      dom_id: '#swagger-ui',\n"
+     "      presets: [SwaggerUIBundle.presets.apis],\n"
+     "      layout: 'BaseLayout'\n"
+     "    });\n"
+     "  </script>\n"
+     "</body>\n"
+     "</html>\n"].

--- a/src/rebar3_nova_release.erl
+++ b/src/rebar3_nova_release.erl
@@ -1,0 +1,60 @@
+-module(rebar3_nova_release).
+
+-export([init/1, do/1, format_error/1]).
+
+-define(PROVIDER, release).
+-define(DEPS, [{default, compile}]).
+
+-spec init(rebar_state:t()) -> {ok, rebar_state:t()}.
+init(State) ->
+    Provider = providers:create([
+            {name, ?PROVIDER},
+            {module, ?MODULE},
+            {namespace, nova},
+            {bare, true},
+            {deps, ?DEPS},
+            {example, "rebar3 nova release --profile prod"},
+            {opts, [
+                {profile, $p, "profile", {string, "prod"}, "Release profile to use"}
+            ]},
+            {short_desc, "Build a Nova release"},
+            {desc, "Regenerates OpenAPI spec if schemas exist, then builds a release"}
+    ]),
+    {ok, rebar_state:add_provider(State, Provider)}.
+
+-spec do(rebar_state:t()) -> {ok, rebar_state:t()} | {error, string()}.
+do(State) ->
+    AppDir = rebar3_nova_utils:get_app_dir(State),
+    {Args, _} = rebar_state:command_parsed_args(State),
+    Profile = proplists:get_value(profile, Args, "prod"),
+
+    SchemaDir = filename:join([AppDir, "priv", "schemas"]),
+    case filelib:is_dir(SchemaDir) of
+        true ->
+            OutputPath = filename:join([AppDir, "priv", "assets", "openapi.json"]),
+            rebar3_nova_utils:ensure_dir(OutputPath),
+            rebar_api:info("Regenerating OpenAPI spec to ~s", [OutputPath]),
+            rebar3_nova_openapi:do(State);
+        false ->
+            ok
+    end,
+
+    ProfileAtom = erlang:list_to_atom(Profile),
+    Providers = rebar_state:providers(State),
+    case providers:get_provider(release, Providers, default) of
+        not_found ->
+            rebar_api:abort("Release provider not found. Is relx configured?", []);
+        ReleaseProvider ->
+            State1 = rebar_state:current_profiles(State, [ProfileAtom]),
+            case providers:do(ReleaseProvider, State1) of
+                {ok, State2} ->
+                    rebar_api:info("Release built successfully with profile '~s'", [Profile]),
+                    {ok, State2};
+                {error, Err} ->
+                    rebar_api:abort("Release failed: ~p", [Err])
+            end
+    end.
+
+-spec format_error(any()) -> iolist().
+format_error(Reason) ->
+    io_lib:format("~p", [Reason]).

--- a/src/rebar3_nova_utils.erl
+++ b/src/rebar3_nova_utils.erl
@@ -1,0 +1,51 @@
+-module(rebar3_nova_utils).
+
+-export([get_app_name/1, get_app_dir/1, ensure_dir/1,
+         write_file_if_not_exists/2, parse_actions/1, load_sys_config/1]).
+
+-spec get_app_name(rebar_state:t()) -> atom().
+get_app_name(State) ->
+    [Hd|_] = rebar_state:project_apps(State),
+    erlang:binary_to_atom(rebar_app_info:name(Hd)).
+
+-spec get_app_dir(rebar_state:t()) -> file:filename().
+get_app_dir(State) ->
+    [Hd|_] = rebar_state:project_apps(State),
+    rebar_app_info:dir(Hd).
+
+-spec ensure_dir(file:filename()) -> ok.
+ensure_dir(Path) ->
+    filelib:ensure_dir(Path).
+
+-spec write_file_if_not_exists(file:filename(), iodata()) -> ok | skipped.
+write_file_if_not_exists(Path, Content) ->
+    case filelib:is_regular(Path) of
+        true ->
+            rebar_api:warn("File already exists, skipping: ~s", [Path]),
+            skipped;
+        false ->
+            ok = ensure_dir(Path),
+            ok = file:write_file(Path, Content),
+            rebar_api:info("Created ~s", [Path]),
+            ok
+    end.
+
+-spec parse_actions(string()) -> [atom()].
+parse_actions(Str) ->
+    Tokens = string:tokens(Str, ","),
+    [erlang:list_to_atom(string:trim(T)) || T <- Tokens].
+
+-spec load_sys_config(rebar_state:t()) -> [{atom(), term()}].
+load_sys_config(State) ->
+    ShellOpts = rebar_state:get(State, shell, []),
+    ConfigPath = case proplists:get_value(config, ShellOpts) of
+        undefined -> "config/dev_sys.config";
+        Path -> Path
+    end,
+    case file:consult(ConfigPath) of
+        {ok, [Config]} when is_list(Config) -> Config;
+        {ok, Config} when is_list(Config) -> Config;
+        {error, _} ->
+            rebar_api:warn("Could not read config from ~s", [ConfigPath]),
+            []
+    end.


### PR DESCRIPTION
## Summary

- **Generators**: `gen_controller`, `gen_router`, `gen_resource`, `gen_test` — scaffold controllers, routers, JSON schemas, and CT suites
- **Introspection**: `openapi` (OpenAPI 3.0.3 spec), `middleware` (per-route-group plugin chains), `config` (Nova config with defaults), `audit` (security checks on routes)
- **Release**: `release` — regenerate OpenAPI spec if schemas exist, then build release

All commands available under `rebar3 nova <command>`.

## New modules

| Module | Command | Description |
|--------|---------|-------------|
| `rebar3_nova_utils` | — | Shared helpers (app name/dir, file writing, config loading) |
| `rebar3_nova_gen_controller` | `gen_controller` | Scaffold controller with CRUD stubs |
| `rebar3_nova_gen_router` | `gen_router` | Scaffold router with `nova_router` behaviour |
| `rebar3_nova_gen_resource` | `gen_resource` | Controller + JSON schema + route hints |
| `rebar3_nova_gen_test` | `gen_test` | CT suite with CRUD test cases |
| `rebar3_nova_openapi` | `openapi` | Generate OpenAPI 3.0.3 spec from compiled routes |
| `rebar3_nova_middleware` | `middleware` | Show plugin chains grouped by route object |
| `rebar3_nova_config` | `config` | Display Nova config keys with values/defaults |
| `rebar3_nova_audit` | `audit` | Audit routes for security issues |
| `rebar3_nova_release` | `release` | Build release with optional OpenAPI regeneration |

## Examples

```
$ rebar3 nova gen_controller --name users
===> Created src/controllers/myapp_users_controller.erl

$ rebar3 nova gen_resource --name products
===> Created src/controllers/myapp_products_controller.erl
===> Created priv/schemas/product.json
===> Add these routes to your router:
       {<<"/products">>, {myapp_products_controller, list}, #{methods => [get]}}
       ...

$ rebar3 nova middleware
=== Global Plugins ===
  (none)

=== Route Groups (myapp_router) ===
  Group: prefix=/api  security=fun myapp_auth:validate_token/1
  Plugins:
    pre_request: nova_cors_plugin #{allow_origins => <<"*">>}
  Routes:
    GET /users -> myapp_users_controller:list
    ...

$ rebar3 nova audit
=== Security Audit ===
  WARNINGS:
    POST /users (myapp_users_controller) has no security
  Summary: 1 warning(s), 3 info(s)
```

## Test plan

- [x] `rebar3 compile` — clean compile, no warnings
- [x] All generator commands create files correctly and skip if already exists
- [x] `middleware` groups routes by route object with correct plugin display
- [x] `config` shows all Nova config keys with values/defaults
- [x] `audit` correctly identifies unsecured mutation routes

🤖 Generated with [Claude Code](https://claude.com/claude-code)