### PR TITLE
feat: add ex_doc config and docs CI step

### DIFF
--- a/.github/workflows/erlang.yml
+++ b/.github/workflows/erlang.yml
@@ -31,3 +31,5 @@ jobs:
       run: rebar3 compile
     - name: Run xref
       run: rebar3 xref
+    - name: Generate docs
+      run: rebar3 ex_doc

--- a/rebar.config
+++ b/rebar.config
@@ -1,4 +1,14 @@
 {erl_opts, [debug_info]}.
+
+{project_plugins, [rebar3_ex_doc]}.
+
+{hex, [{doc, #{provider => ex_doc}}]}.
+
+{ex_doc, [{proglang, erlang},
+          {main, <<"readme">>},
+          {extras, [<<"README.md">>, <<"LICENSE">>]},
+          {source_url, <<"https://github.com/novaframework/rebar3_nova">>}]}.
+
 {deps, [
          nova,
          enotify


### PR DESCRIPTION
## Summary
- Add `rebar3_ex_doc` as project plugin with hex doc config
- Add `rebar3 ex_doc` step to CI workflow

## Test plan
- [ ] Verify `rebar3 ex_doc` passes in CI
- [ ] Publish to hex and verify docs appear on hexdocs.pm

🤖 Generated with [Claude Code](https://claude.com/claude-code)