### PR TITLE
feat: add nova_kura project template

### DIFF
--- a/priv/templates/nova.template
+++ b/priv/templates/nova.template
@@ -24,3 +24,5 @@
 {file, "nova/controller.dtl", "{{name}}/src/views/{{name}}_main.dtl"}.
 {file, "nova/.tool-versions", "{{name}}/.tool-versions"}.
 {file, "nova/.gitignore", "{{name}}/.gitignore"}.
+{template, "nova/Dockerfile", "{{name}}/Dockerfile"}.
+{file, "nova/.dockerignore", "{{name}}/.dockerignore"}.

--- a/priv/templates/nova.template
+++ b/priv/templates/nova.template
@@ -17,6 +17,7 @@
 {template, "nova/sup.erl", "{{name}}/src/{{name}}_sup.erl"}.
 {template, "nova/router.erl", "{{name}}/src/{{name}}_router.erl"}.
 {template, "nova/controller.erl", "{{name}}/src/controllers/{{name}}_main_controller.erl"}.
+{template, "nova/health_controller.erl", "{{name}}/src/controllers/{{name}}_health_controller.erl"}.
 {template, "nova/rebar.config", "{{name}}/rebar.config"}.
 {template, "nova/vm.args.src", "{{name}}/config/vm.args.src"}.
 
@@ -26,3 +27,4 @@
 {file, "nova/.gitignore", "{{name}}/.gitignore"}.
 {template, "nova/Dockerfile", "{{name}}/Dockerfile"}.
 {file, "nova/.dockerignore", "{{name}}/.dockerignore"}.
+{template, "nova/fly.toml", "{{name}}/fly.toml"}.

--- a/priv/templates/nova/.dockerignore
+++ b/priv/templates/nova/.dockerignore
@@ -1,0 +1,10 @@
+_build
+.rebar3
+.rebar
+.git
+log
+logs
+erl_crash.dump
+rebar3.crashdump
+*.beam
+*.o

--- a/priv/templates/nova/Dockerfile
+++ b/priv/templates/nova/Dockerfile
@@ -1,0 +1,29 @@
+ARG ERLANG_VERSION
+ARG REBAR_VERSION
+
+FROM erlang:${ERLANG_VERSION} AS builder
+
+RUN wget -q "https://github.com/erlang/rebar3/releases/download/${REBAR_VERSION}/rebar3" -O /usr/local/bin/rebar3 && \
+    chmod +x /usr/local/bin/rebar3
+
+WORKDIR /app
+
+COPY rebar.config rebar.lock ./
+RUN rebar3 compile --deps_only
+
+COPY . .
+RUN rebar3 as prod release
+
+FROM debian:bookworm-slim
+
+RUN apt-get update && \
+    apt-get install -y --no-install-recommends libncurses5 libssl3 libstdc++6 && \
+    rm -rf /var/lib/apt/lists/*
+
+WORKDIR /app
+
+COPY --from=builder /app/_build/prod/rel/{{name}} ./
+
+EXPOSE 8080
+
+CMD ["bin/{{name}}", "foreground"]

--- a/priv/templates/nova/fly.toml
+++ b/priv/templates/nova/fly.toml
@@ -1,0 +1,35 @@
+app = '{{name}}'
+primary_region = 'ams'
+
+[build]
+
+[http_service]
+  internal_port = 8080
+  force_https = true
+  auto_stop_machines = 'stop'
+  auto_start_machines = true
+  min_machines_running = 0
+  processes = ['app']
+
+[checks]
+  [checks.health]
+    grace_period = "10s"
+    interval = "15s"
+    method = "GET"
+    path = "/healthz"
+    port = 8080
+    timeout = "5s"
+    type = "http"
+
+  [checks.ready]
+    grace_period = "15s"
+    interval = "15s"
+    method = "GET"
+    path = "/readyz"
+    port = 8080
+    timeout = "5s"
+    type = "http"
+
+[[vm]]
+  size = 'shared-cpu-1x'
+  memory = '512mb'

--- a/priv/templates/nova/health_controller.erl
+++ b/priv/templates/nova/health_controller.erl
@@ -1,0 +1,20 @@
+-module({{name}}_health_controller).
+-export([
+    healthz/1,
+    readyz/1
+]).
+
+healthz(_Req) ->
+    {json, #{status => <<"ok">>}}.
+
+readyz(_Req) ->
+    ready_response(check_ready()).
+
+ready_response(true) ->
+    {json, #{status => <<"ready">>}};
+ready_response(false) ->
+    {status, 503, #{}, #{status => <<"unavailable">>}}.
+
+check_ready() ->
+    Apps = application:which_applications(),
+    lists:keymember({{name}}, 1, Apps).

--- a/priv/templates/nova/prod_sys.config.src
+++ b/priv/templates/nova/prod_sys.config.src
@@ -5,11 +5,12 @@
            {logger_level, info},
            {logger,
             [{handler, default, logger_std_h,
-              #{level => error,
-                config => #{file => "log/erlang.log"}}}
+              #{formatter => {nova_jsonlogger, #{new_line => true}}}}
             ]}
           ]},
  {nova, [
+         {shutdown_delay, 5000},
+         {shutdown_drain_timeout, 15000},
          {use_stacktrace, false},
          {environment, prod},
          {cowboy_configuration, #{

--- a/priv/templates/nova/router.erl
+++ b/priv/templates/nova/router.erl
@@ -6,15 +6,23 @@
 ]).
 
 %% The Environment-variable is defined in your sys.config in {nova, [{environment, Value}]}
-routes(_Environment) ->
+routes(Environment) ->
     [
         #{
             prefix => "",
             security => false,
-            routes => [
-                {"/", fun {{name}}_main_controller:index/1, #{methods => [get]}},
-                {"/healthz", fun {{name}}_health_controller:healthz/1, #{methods => [get]}},
-                {"/readyz", fun {{name}}_health_controller:readyz/1, #{methods => [get]}}
-            ]
+            routes => base_routes() ++ dev_routes(Environment)
         }
     ].
+
+base_routes() ->
+    [
+        {"/", fun {{name}}_main_controller:index/1, #{methods => [get]}},
+        {"/healthz", fun {{name}}_health_controller:healthz/1, #{methods => [get]}},
+        {"/readyz", fun {{name}}_health_controller:readyz/1, #{methods => [get]}}
+    ].
+
+dev_routes(dev) ->
+    [{"/assets/[...]", "assets"}];
+dev_routes(_) ->
+    [].

--- a/priv/templates/nova/router.erl
+++ b/priv/templates/nova/router.erl
@@ -13,7 +13,8 @@ routes(_Environment) ->
             security => false,
             routes => [
                 {"/", fun {{name}}_main_controller:index/1, #{methods => [get]}},
-                {"/heartbeat", fun(_) -> {status, 200} end, #{methods => [get]}}
+                {"/healthz", fun {{name}}_health_controller:healthz/1, #{methods => [get]}},
+                {"/readyz", fun {{name}}_health_controller:readyz/1, #{methods => [get]}}
             ]
         }
     ].

--- a/priv/templates/nova/vm.args.src
+++ b/priv/templates/nova/vm.args.src
@@ -1,6 +1,7 @@
--sname '{{name}}'
-
--setcookie {{name}}_cookie
+## Distributed Erlang is disabled by default.
+## Uncomment the lines below if you need distribution.
+## -sname '{{name}}'
+## -setcookie {{name}}_cookie
 
 +K true
 +A30

--- a/priv/templates/nova_kura.template
+++ b/priv/templates/nova_kura.template
@@ -1,0 +1,33 @@
+{description, "Nova project with Kura (PostgreSQL ORM)"}.
+{variables, [
+    {name, "project", "Name of the project"}
+]}.
+
+{dir, "{{name}}"}.
+{dir, "{{name}}/priv"}.
+{dir, "{{name}}/priv/assets"}.
+{dir, "{{name}}/config"}.
+{dir, "{{name}}/src/controllers"}.
+{dir, "{{name}}/src/views"}.
+{dir, "{{name}}/src/schemas"}.
+{dir, "{{name}}/src/migrations"}.
+
+{template, "nova_kura/dev_sys.config.src", "{{name}}/config/dev_sys.config.src"}.
+{template, "nova_kura/prod_sys.config.src", "{{name}}/config/prod_sys.config.src"}.
+{template, "nova_kura/app.src", "{{name}}/src/{{name}}.app.src"}.
+{template, "nova_kura/app.erl", "{{name}}/src/{{name}}_app.erl"}.
+{template, "nova_kura/sup.erl", "{{name}}/src/{{name}}_sup.erl"}.
+{template, "nova_kura/repo.erl", "{{name}}/src/{{name}}_repo.erl"}.
+{template, "nova/router.erl", "{{name}}/src/{{name}}_router.erl"}.
+{template, "nova/controller.erl", "{{name}}/src/controllers/{{name}}_main_controller.erl"}.
+{template, "nova/health_controller.erl", "{{name}}/src/controllers/{{name}}_health_controller.erl"}.
+{template, "nova_kura/rebar.config", "{{name}}/rebar.config"}.
+{template, "nova/vm.args.src", "{{name}}/config/vm.args.src"}.
+
+{file, "nova/favicon.ico", "{{name}}/priv/assets/favicon.ico"}.
+{file, "nova/controller.dtl", "{{name}}/src/views/{{name}}_main.dtl"}.
+{file, "nova/.tool-versions", "{{name}}/.tool-versions"}.
+{file, "nova/.gitignore", "{{name}}/.gitignore"}.
+{template, "nova/Dockerfile", "{{name}}/Dockerfile"}.
+{file, "nova/.dockerignore", "{{name}}/.dockerignore"}.
+{template, "nova/fly.toml", "{{name}}/fly.toml"}.

--- a/priv/templates/nova_kura/app.erl
+++ b/priv/templates/nova_kura/app.erl
@@ -1,0 +1,13 @@
+-module({{name}}_app).
+
+-behaviour(application).
+
+-export([start/2, stop/1]).
+
+start(_StartType, _StartArgs) ->
+    {ok, Pid} = {{name}}_sup:start_link(),
+    ok = kura:start({{name}}_repo),
+    {ok, Pid}.
+
+stop(_State) ->
+    ok.

--- a/priv/templates/nova_kura/app.src
+++ b/priv/templates/nova_kura/app.src
@@ -1,0 +1,19 @@
+%% -*- mode: erlang;erlang-indent-level: 4;indent-tabs-mode: nil -*-
+{application, {{name}}, [
+    {description, "{{name}} managed by Nova"},
+    {vsn, git},
+    {registered, []},
+    {mod, {{{name}}_app, []}},
+    {included_applications, []},
+    {applications, [
+        kernel,
+        stdlib,
+        nova,
+        kura
+    ]},
+    {env, []},
+    {modules, []},
+    {maintainers, []},
+    {licenses, ["Apache 2.0"]},
+    {links, []}
+]}.

--- a/priv/templates/nova_kura/dev_sys.config.src
+++ b/priv/templates/nova_kura/dev_sys.config.src
@@ -1,0 +1,36 @@
+%% -*- mode: erlang;erlang-indent-level: 4;indent-tabs-mode: nil -*-
+
+[
+ {kernel, [
+           {logger_level, debug},
+           #{formatter => {flatlog, #{
+                                      map_depth => 3,
+                                      term_depth => 50,
+                                      colored => true,
+                                      template => [colored_start, "[\033[1m", level, "\033[0m", colored_start,"] [", time, "]",
+                                                   colored_end, " ", msg, " (", mfa, ")\n"]
+                                     }}}
+          ]},
+ {nova, [
+         {use_stacktrace, true},
+         {environment, dev},
+         {cowboy_configuration, #{
+                                  port => 8080
+                                 }},
+         {dev_mode, true},
+         {bootstrap_application, {{name}}},
+         {plugins, [
+                    {pre_request, nova_request_plugin, #{decode_json_body => true}}
+                   ]}
+        ]},
+ {{{name}}, [
+         {{{name}}_repo, #{
+             database => <<"{{name}}_dev">>,
+             hostname => <<"localhost">>,
+             port => 5432,
+             username => <<"postgres">>,
+             password => <<"postgres">>,
+             pool_size => 10
+         }}
+        ]}
+].

--- a/priv/templates/nova_kura/prod_sys.config.src
+++ b/priv/templates/nova_kura/prod_sys.config.src
@@ -1,0 +1,37 @@
+%% -*- mode: erlang;erlang-indent-level: 4;indent-tabs-mode: nil -*-
+
+[
+ {kernel, [
+           {logger_level, info},
+           {logger,
+            [{handler, default, logger_std_h,
+              #{formatter => {nova_jsonlogger, #{new_line => true}}}}
+            ]}
+          ]},
+ {nova, [
+         {shutdown_delay, 5000},
+         {shutdown_drain_timeout, 15000},
+         {use_stacktrace, false},
+         {environment, prod},
+         {cowboy_configuration, #{
+                                  port => 8080
+                                 }},
+         {dev_mode, false},
+         {bootstrap_application, {{name}}},
+         {plugins, [
+                    {pre_request, nova_request_plugin, #{decode_json_body => true}}
+                   ]}
+        ]},
+ {{{name}}, [
+         {{{name}}_repo, #{
+             database => <<"{{name}}_prod">>,
+             hostname => <<"localhost">>,
+             port => 5432,
+             username => <<"postgres">>,
+             password => <<"postgres">>,
+             pool_size => 20
+         }}
+        ]}
+  %% In production, set DATABASE_URL environment variable instead.
+  %% The repo init/1 callback will parse it automatically.
+].

--- a/priv/templates/nova_kura/rebar.config
+++ b/priv/templates/nova_kura/rebar.config
@@ -1,0 +1,82 @@
+%% -*- mode: erlang;erlang-indent-level: 4;indent-tabs-mode: nil -*-
+
+{erl_opts, [debug_info]}.
+{src_dirs, [{"src", [{recursive, true}]}]}.
+{shell, [{config, "./config/dev_sys.config.src"}]}.
+
+{erlydtl_opts, [
+    {doc_root, "src/views"},
+    {recursive, true},
+    {libraries, [
+        {nova_erlydtl_inventory, nova_erlydtl_inventory}
+    ]},
+    {default_libraries, [nova_erlydtl_inventory]}
+]}.
+
+{deps, [
+    nova,
+    kura,
+    %% Used for logging - Change if needed
+    {flatlog, "0.1.2"}
+]}.
+
+%% Release profiles
+%% To create a release just run
+%% rebar3 as prod release
+{relx, [
+    {release, {{{name}}, git}, [
+        {{name}},
+        sasl
+    ]},
+    {mode, dev},
+    {sys_config_src, "./config/dev_sys.config.src"},
+    {vm_args_src, "./config/vm.args.src"}
+]}.
+
+{profiles, [
+    {prod, [
+        {relx, [
+            {mode, prod},
+            {sys_config_src, "./config/prod_sys.config.src"}
+        ]}
+    ]},
+    {test, [
+        {erl_opts, [nowarn_export_all, warnings_as_errors, {i, "test/util"}]},
+        {deps, [
+            {meck, "1.1.0"}
+        ]},
+        {ct_opts, [{sys_config, "./config/dev_sys.config.src"}]},
+        {extra_src_dirs, [{"test", [{recursive, true}]}]},
+        {xref_extra_paths, ["test"]}
+    ]}
+]}.
+
+{dialyzer, [{plt_apps, all_deps}]}.
+
+%% Plugins for rebar3
+{project_plugins, [
+    {rebar3_erlydtl_plugin, ".*",
+        {git, "https://github.com/erlydtl/rebar3_erlydtl_plugin.git", {branch, "master"}}},
+    {rebar3_nova, ".*",
+        {git, "https://github.com/novaframework/rebar3_nova.git", {branch, "master"}}},
+    {erlfmt, "~>1.7"}
+]}.
+
+{erlfmt, [
+    write,
+    {files, [
+        "rebar.config",
+        "src/*.app.src",
+        "src/**/{*.erl, *.hrl}",
+        "test/**/{*.erl, *.hrl}"
+    ]},
+    {exclude_files, ["config/vm.args.src", "config/prod_sys.config.src"]}
+]}.
+
+{xref_checks, [
+    undefined_function_calls,
+    undefined_functions,
+    locals_not_used,
+    deprecated_function_calls,
+    deprecated_functions
+]}.

--- a/priv/templates/nova_kura/repo.erl
+++ b/priv/templates/nova_kura/repo.erl
@@ -1,0 +1,37 @@
+-module({{name}}_repo).
+-behaviour(kura_repo).
+
+-export([otp_app/0, init/1]).
+
+otp_app() -> {{name}}.
+
+init(Config) ->
+    maybe_apply_database_url(Config).
+
+maybe_apply_database_url(Config) ->
+    case os:getenv("DATABASE_URL") of
+        false ->
+            Config;
+        Url ->
+            parse_database_url(Url, Config)
+    end.
+
+parse_database_url(Url, Config) ->
+    case uri_string:parse(list_to_binary(Url)) of
+        #{scheme := <<"postgres", _/binary>>,
+          host := Host,
+          path := Path,
+          userinfo := UserInfo} = Parsed ->
+            [User, Pass] = binary:split(UserInfo, <<":">>),
+            Db = binary:part(Path, 1, byte_size(Path) - 1),
+            Port = maps:get(port, Parsed, 5432),
+            Config#{
+                hostname => Host,
+                port => Port,
+                username => User,
+                password => Pass,
+                database => Db
+            };
+        _ ->
+            Config
+    end.

--- a/priv/templates/nova_kura/sup.erl
+++ b/priv/templates/nova_kura/sup.erl
@@ -1,0 +1,16 @@
+-module({{name}}_sup).
+
+-behaviour(supervisor).
+
+-export([start_link/0]).
+-export([init/1]).
+
+-define(SERVER, ?MODULE).
+
+start_link() ->
+    supervisor:start_link({local, ?SERVER}, ?MODULE, []).
+
+init([]) ->
+    SupFlags = #{strategy => one_for_all},
+    ChildSpecs = [],
+    {ok, {SupFlags, ChildSpecs}}.

--- a/src/rebar3_nova.erl
+++ b/src/rebar3_nova.erl
@@ -12,14 +12,16 @@ init(State) ->
                         [rebar3_nova_prv, rebar3_nova_serve, rebar3_nova_routes, rebar3_nova_openapi,
                          rebar3_nova_gen_controller, rebar3_nova_gen_resource,
                          rebar3_nova_gen_test, rebar3_nova_gen_auth, rebar3_nova_middleware,
-                         rebar3_nova_config, rebar3_nova_audit, rebar3_nova_release]);
+                         rebar3_nova_config, rebar3_nova_audit, rebar3_nova_release,
+                         rebar3_nova_fly]);
         ["git"] ->
             rebar_api:info("Compiling with rebar3 from git - make sure you know what you are doing"),
             lists:foldl(fun provider_init/2, {ok, State},
                         [rebar3_nova_prv, rebar3_nova_serve, rebar3_nova_routes, rebar3_nova_openapi,
                          rebar3_nova_gen_controller, rebar3_nova_gen_resource,
                          rebar3_nova_gen_test, rebar3_nova_gen_auth, rebar3_nova_middleware,
-                         rebar3_nova_config, rebar3_nova_audit, rebar3_nova_release]);
+                         rebar3_nova_config, rebar3_nova_audit, rebar3_nova_release,
+                         rebar3_nova_fly]);
         SomethingElse ->
             rebar_api:abort("Nova needs Rebar > 3.15 to function. Your version is: ~p. Please consider upgrading.", [SomethingElse])
     end.

--- a/src/rebar3_nova_fly.erl
+++ b/src/rebar3_nova_fly.erl
@@ -1,0 +1,181 @@
+-module(rebar3_nova_fly).
+
+-export([init/1, do/1, format_error/1]).
+
+-define(PROVIDER, fly).
+-define(DEPS, []).
+
+-spec init(rebar_state:t()) -> {ok, rebar_state:t()}.
+init(State) ->
+    Provider = providers:create([
+        {name, ?PROVIDER},
+        {module, ?MODULE},
+        {namespace, nova},
+        {bare, true},
+        {deps, ?DEPS},
+        {example, "rebar3 nova fly deploy"},
+        {opts, [
+            {action, undefined, undefined, string, "Action: init, deploy, or status"}
+        ]},
+        {short_desc, "Deploy Nova application to Fly.io"},
+        {desc,
+            "Manage Fly.io deployments for Nova applications.\n\n"
+            "Actions:\n"
+            "  init    - Create a new Fly.io app (generates fly.toml if missing)\n"
+            "  deploy  - Build and deploy to Fly.io\n"
+            "  status  - Show app status on Fly.io\n"}
+    ]),
+    {ok, rebar_state:add_provider(State, Provider)}.
+
+-spec do(rebar_state:t()) -> {ok, rebar_state:t()} | {error, string()}.
+do(State) ->
+    ensure_flyctl(),
+    {Args, _} = rebar_state:command_parsed_args(State),
+    Action = proplists:get_value(action, Args),
+    AppName = rebar3_nova_utils:get_app_name(State),
+    AppDir = rebar3_nova_utils:get_app_dir(State),
+    run_action(Action, AppName, AppDir, State).
+
+-spec format_error(any()) -> iolist().
+format_error(Reason) ->
+    io_lib:format("~p", [Reason]).
+
+%%--------------------------------------------------------------------
+%% Actions
+%%--------------------------------------------------------------------
+
+run_action("init", AppName, AppDir, State) ->
+    fly_init(AppName, AppDir, State);
+run_action("deploy", _AppName, AppDir, State) ->
+    fly_deploy(AppDir, State);
+run_action("status", _AppName, _AppDir, State) ->
+    fly_status(State);
+run_action(undefined, _AppName, AppDir, State) ->
+    fly_deploy(AppDir, State);
+run_action(Other, _AppName, _AppDir, _State) ->
+    rebar_api:abort("Unknown action: ~s. Use init, deploy, or status.", [Other]).
+
+%%--------------------------------------------------------------------
+%% Internal functions
+%%--------------------------------------------------------------------
+
+ensure_flyctl() ->
+    case os:find_executable("fly") of
+        false ->
+            rebar_api:abort(
+                "flyctl not found. Install it: curl -L https://fly.io/install.sh | sh", []);
+        _Path ->
+            ok
+    end.
+
+fly_init(AppName, AppDir, State) ->
+    maybe_generate_fly_toml(AppName, AppDir),
+    rebar_api:info("Creating Fly.io app...", []),
+    Cmd = ["cd ", AppDir, " && fly launch --no-deploy --copy-config --yes"],
+    require_cmd(Cmd, "fly launch"),
+    rebar_api:info("Fly.io app created. Run 'rebar3 nova fly deploy' to deploy.", []),
+    {ok, State}.
+
+fly_deploy(AppDir, State) ->
+    rebar_api:info("Deploying to Fly.io...", []),
+    ToolVersions = filename:join(AppDir, ".tool-versions"),
+    BuildArgs = build_args_from_tool_versions(ToolVersions),
+    Cmd = ["cd ", AppDir, " && fly deploy", BuildArgs],
+    require_cmd(Cmd, "fly deploy"),
+    rebar_api:info("Deploy complete!", []),
+    {ok, State}.
+
+fly_status(State) ->
+    require_cmd("fly status", "fly status"),
+    {ok, State}.
+
+maybe_generate_fly_toml(AppName, AppDir) ->
+    FlyToml = filename:join(AppDir, "fly.toml"),
+    case filelib:is_regular(FlyToml) of
+        true ->
+            rebar_api:info("fly.toml already exists, launching app...", []);
+        false ->
+            rebar_api:info("Generating fly.toml for ~s", [AppName]),
+            generate_fly_toml(AppName, FlyToml)
+    end.
+
+generate_fly_toml(AppName, Path) ->
+    Content = [
+        "app = '", atom_to_list(AppName), "'\n",
+        "primary_region = 'ams'\n",
+        "\n",
+        "[build]\n",
+        "\n",
+        "[http_service]\n",
+        "  internal_port = 8080\n",
+        "  force_https = true\n",
+        "  auto_stop_machines = 'stop'\n",
+        "  auto_start_machines = true\n",
+        "  min_machines_running = 0\n",
+        "  processes = ['app']\n",
+        "\n",
+        "[checks]\n",
+        "  [checks.health]\n",
+        "    grace_period = \"10s\"\n",
+        "    interval = \"15s\"\n",
+        "    method = \"GET\"\n",
+        "    path = \"/healthz\"\n",
+        "    port = 8080\n",
+        "    timeout = \"5s\"\n",
+        "    type = \"http\"\n",
+        "\n",
+        "  [checks.ready]\n",
+        "    grace_period = \"15s\"\n",
+        "    interval = \"15s\"\n",
+        "    method = \"GET\"\n",
+        "    path = \"/readyz\"\n",
+        "    port = 8080\n",
+        "    timeout = \"5s\"\n",
+        "    type = \"http\"\n",
+        "\n",
+        "[[vm]]\n",
+        "  size = 'shared-cpu-1x'\n",
+        "  memory = '512mb'\n"
+    ],
+    ok = file:write_file(Path, Content),
+    rebar_api:info("Created ~s", [Path]).
+
+require_cmd(Cmd, Label) ->
+    case run_cmd(Cmd) of
+        0 -> ok;
+        Code -> rebar_api:abort("~s failed with exit code ~p", [Label, Code])
+    end.
+
+build_args_from_tool_versions(ToolVersions) ->
+    case file:read_file(ToolVersions) of
+        {ok, Bin} ->
+            Lines = string:split(binary_to_list(Bin), "\n", all),
+            lists:flatmap(fun tool_version_to_arg/1, Lines);
+        {error, _} ->
+            []
+    end.
+
+tool_version_to_arg(Line) ->
+    case string:tokens(string:trim(Line), " ") of
+        ["erlang", Vsn] ->
+            [" --build-arg ERLANG_VERSION=", Vsn];
+        ["rebar", Vsn] ->
+            [" --build-arg REBAR_VERSION=", Vsn];
+        _ ->
+            []
+    end.
+
+run_cmd(Cmd) ->
+    Port = open_port({spawn, lists:flatten(Cmd)}, [
+        exit_status, binary, stderr_to_stdout, {line, 1024}
+    ]),
+    collect_port_output(Port).
+
+collect_port_output(Port) ->
+    receive
+        {Port, {data, {_, Line}}} ->
+            rebar_api:info("~s", [Line]),
+            collect_port_output(Port);
+        {Port, {exit_status, Status}} ->
+            Status
+    end.


### PR DESCRIPTION
## Summary
- New template: `rebar3 new nova_kura my_app` scaffolds a Nova project with Kura ORM
- Repo module with `DATABASE_URL` parsing via `uri_string` for cloud deploys (Fly.io, GCP, etc.)
- Dev sys.config with local postgres defaults, prod with JSON logging + graceful shutdown
- Creates `src/migrations/` and `src/schemas/` directories
- Reuses shared template files (router, health controller, Dockerfile, fly.toml)

**Depends on:** #55

## Usage
```bash
rebar3 new nova_kura my_app
cd my_app
# Create postgres database
createdb my_app_dev
# Start dev server
rebar3 shell
```

## Template contents
| File | Purpose |
|------|---------|
| `src/{name}_repo.erl` | Kura repo with DATABASE_URL support |
| `src/{name}_app.erl` | App startup with `kura:start/1` |
| `config/dev_sys.config.src` | Local postgres config |
| `config/prod_sys.config.src` | Prod config (uses DATABASE_URL) |
| `src/migrations/` | Migration directory |
| `src/schemas/` | Schema directory |

## Test plan
- [ ] `rebar3 new nova_kura test_app` generates all expected files
- [ ] Repo module compiles and implements `kura_repo` behaviour
- [ ] `DATABASE_URL` parsing handles standard postgres:// URLs
- [ ] Dev config connects to local postgres
- [ ] Template reuses shared nova files correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)