### PR TITLE
feat: modernize default landing page

### DIFF
--- a/priv/templates/nova/controller.dtl
+++ b/priv/templates/nova/controller.dtl
@@ -1,107 +1,258 @@
-<html>
-  <head>
-    <title>Nova is running</title>
-    <style>
-      html {
-          height: 100%;
-          background: radial-gradient(ellipse at bottom, #1b2735 0%, #090a0f 100%);
-          overflow: hidden;
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="utf-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <title>Nova is running</title>
+  <style>
+    *,
+    *::before,
+    *::after {
+      margin: 0;
+      padding: 0;
+      box-sizing: border-box;
+    }
+
+    :root {
+      --bg: #fafafa;
+      --surface: #fff;
+      --text: #1a1a2e;
+      --text-secondary: #64648c;
+      --accent: #7c3aed;
+      --accent-light: #a78bfa;
+      --border: #e5e5f0;
+      --code-bg: #f3f0ff;
+      --code-text: #5b21b6;
+      --shadow: 0 1px 3px rgba(0, 0, 0, 0.06), 0 1px 2px rgba(0, 0, 0, 0.04);
+      --shadow-lg: 0 10px 30px rgba(0, 0, 0, 0.06);
+      --radius: 12px;
+    }
+
+    @media (prefers-color-scheme: dark) {
+      :root {
+        --bg: #0f0f1a;
+        --surface: #1a1a2e;
+        --text: #e5e5f0;
+        --text-secondary: #9898b8;
+        --accent: #a78bfa;
+        --accent-light: #c4b5fd;
+        --border: #2a2a40;
+        --code-bg: #1e1b2e;
+        --code-text: #c4b5fd;
+        --shadow: 0 1px 3px rgba(0, 0, 0, 0.2);
+        --shadow-lg: 0 10px 30px rgba(0, 0, 0, 0.3);
+      }
+    }
+
+    html {
+      height: 100%;
+    }
+
+    body {
+      min-height: 100%;
+      font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto,
+        Helvetica, Arial, sans-serif, "Apple Color Emoji", "Segoe UI Emoji";
+      background: var(--bg);
+      color: var(--text);
+      display: flex;
+      align-items: center;
+      justify-content: center;
+      padding: 2rem;
+      -webkit-font-smoothing: antialiased;
+    }
+
+    .container {
+      max-width: 560px;
+      width: 100%;
+    }
+
+    .card {
+      background: var(--surface);
+      border: 1px solid var(--border);
+      border-radius: var(--radius);
+      box-shadow: var(--shadow-lg);
+      padding: 3rem 2.5rem;
+      text-align: center;
+    }
+
+    .logo {
+      display: block;
+      margin-left: auto;
+      margin-right: auto;
+      width: 240px;
+      height: auto;
+      margin-bottom: 1.5rem;
+      opacity: 0;
+      animation: fade-in 0.6s ease forwards;
+    }
+
+    .logo .wordmark {
+      fill: var(--text);
+    }
+
+    .logo .mark {
+      fill: var(--accent);
+    }
+
+    .status {
+      display: inline-flex;
+      align-items: center;
+      gap: 0.5rem;
+      padding: 0.35rem 1rem;
+      background: var(--code-bg);
+      border-radius: 999px;
+      font-size: 0.85rem;
+      font-weight: 500;
+      color: var(--code-text);
+      margin-bottom: 1.5rem;
+      opacity: 0;
+      animation: fade-in 0.6s ease 0.15s forwards;
+    }
+
+    .status-dot {
+      width: 8px;
+      height: 8px;
+      background: #22c55e;
+      border-radius: 50%;
+      animation: pulse 2s ease-in-out infinite;
+    }
+
+    .message {
+      font-size: 1.1rem;
+      color: var(--text-secondary);
+      line-height: 1.6;
+      margin-bottom: 2rem;
+      opacity: 0;
+      animation: fade-in 0.6s ease 0.3s forwards;
+    }
+
+    .message code {
+      background: var(--code-bg);
+      color: var(--code-text);
+      padding: 0.15rem 0.5rem;
+      border-radius: 6px;
+      font-size: 0.95rem;
+      font-family: "SF Mono", SFMono-Regular, ui-monospace, Menlo, Consolas,
+        monospace;
+    }
+
+    .links {
+      display: flex;
+      gap: 0.75rem;
+      justify-content: center;
+      flex-wrap: wrap;
+      opacity: 0;
+      animation: fade-in 0.6s ease 0.45s forwards;
+    }
+
+    .links a {
+      display: inline-flex;
+      align-items: center;
+      gap: 0.4rem;
+      padding: 0.55rem 1.2rem;
+      border-radius: 8px;
+      font-size: 0.875rem;
+      font-weight: 500;
+      text-decoration: none;
+      transition: all 0.15s ease;
+    }
+
+    .links a.primary {
+      background: var(--accent);
+      color: #fff;
+    }
+
+    .links a.primary:hover {
+      opacity: 0.9;
+      transform: translateY(-1px);
+    }
+
+    .links a.secondary {
+      background: var(--code-bg);
+      color: var(--code-text);
+    }
+
+    .links a.secondary:hover {
+      opacity: 0.8;
+      transform: translateY(-1px);
+    }
+
+    .footer {
+      text-align: center;
+      margin-top: 1.5rem;
+      font-size: 0.8rem;
+      color: var(--text-secondary);
+      opacity: 0;
+      animation: fade-in 0.6s ease 0.6s forwards;
+    }
+
+    .footer a {
+      color: var(--accent-light);
+      text-decoration: none;
+    }
+
+    .footer a:hover {
+      text-decoration: underline;
+    }
+
+    @keyframes fade-in {
+      from {
+        opacity: 0;
+        transform: translateY(8px);
+      }
+      to {
+        opacity: 1;
+        transform: translateY(0);
+      }
+    }
+
+    @keyframes pulse {
+      0%, 100% { opacity: 1; }
+      50% { opacity: 0.5; }
+    }
+
+    @media (max-width: 480px) {
+      .card {
+        padding: 2rem 1.5rem;
       }
 
-      #stars {
-          width: 1px;
-          height: 1px;
-          background: transparent;
-          box-shadow: 640px 1696px #FFF , 1160px 1058px #FFF , 1227px 156px #FFF , 1138px 1418px #FFF , 1727px 329px #FFF , 37px 279px #FFF , 1417px 1804px #FFF , 1837px 1261px #FFF , 856px 1149px #FFF , 43px 510px #FFF , 1140px 520px #FFF , 1356px 354px #FFF , 479px 1893px #FFF , 117px 1184px #FFF , 1637px 653px #FFF , 1079px 1938px #FFF , 987px 484px #FFF , 1574px 465px #FFF , 1961px 1762px #FFF , 738px 418px #FFF , 51px 1272px #FFF , 158px 859px #FFF , 1797px 503px #FFF , 83px 253px #FFF , 592px 1108px #FFF , 1832px 392px #FFF , 679px 1536px #FFF , 703px 1941px #FFF , 1932px 770px #FFF , 1755px 802px #FFF , 1643px 1784px #FFF , 1967px 163px #FFF , 1063px 1983px #FFF , 1509px 880px #FFF , 1891px 651px #FFF , 1832px 1644px #FFF , 1260px 638px #FFF , 453px 450px #FFF , 1977px 1782px #FFF , 208px 1856px #FFF , 1941px 1343px #FFF , 894px 872px #FFF , 936px 1444px #FFF , 503px 438px #FFF , 118px 1556px #FFF , 1591px 883px #FFF , 940px 1674px #FFF , 76px 1676px #FFF , 528px 938px #FFF , 772px 359px #FFF , 1934px 731px #FFF , 1787px 72px #FFF , 1445px 780px #FFF , 677px 1306px #FFF , 1021px 900px #FFF , 199px 343px #FFF , 1194px 1524px #FFF , 75px 1700px #FFF , 1323px 1400px #FFF , 712px 1806px #FFF , 136px 803px #FFF , 842px 299px #FFF , 138px 570px #FFF , 245px 975px #FFF , 1305px 1210px #FFF , 1615px 164px #FFF , 1710px 568px #FFF , 494px 397px #FFF , 598px 286px #FFF , 887px 1775px #FFF , 293px 1063px #FFF , 189px 49px #FFF , 1275px 199px #FFF , 693px 1163px #FFF , 1186px 322px #FFF , 527px 807px #FFF , 1412px 1246px #FFF , 1397px 843px #FFF , 1860px 480px #FFF , 847px 777px #FFF , 431px 917px #FFF , 487px 1662px #FFF , 1226px 1930px #FFF , 1109px 987px #FFF , 1110px 162px #FFF , 486px 1510px #FFF , 1364px 1018px #FFF , 255px 1488px #FFF , 1960px 1688px #FFF , 457px 1263px #FFF , 1202px 502px #FFF , 1206px 1974px #FFF , 1130px 1127px #FFF , 1164px 383px #FFF , 893px 1646px #FFF , 1575px 1292px #FFF , 600px 1489px #FFF , 348px 591px #FFF , 915px 1754px #FFF , 825px 757px #FFF , 379px 1727px #FFF , 573px 1729px #FFF , 1555px 1569px #FFF , 293px 512px #FFF , 1743px 470px #FFF , 1872px 1789px #FFF , 1535px 564px #FFF , 732px 92px #FFF , 1114px 777px #FFF , 1655px 1514px #FFF , 1781px 1308px #FFF , 1204px 1545px #FFF , 1068px 895px #FFF , 1956px 275px #FFF , 157px 1972px #FFF , 189px 254px #FFF , 1644px 65px #FFF , 324px 1851px #FFF , 54px 588px #FFF , 1183px 1600px #FFF , 1781px 1990px #FFF , 1403px 781px #FFF , 55px 102px #FFF , 335px 1225px #FFF , 934px 1000px #FFF , 642px 1489px #FFF , 430px 170px #FFF , 1708px 1737px #FFF , 563px 1802px #FFF , 702px 1114px #FFF , 1821px 487px #FFF , 1874px 267px #FFF , 466px 305px #FFF , 1622px 1459px #FFF , 50px 1693px #FFF , 1320px 64px #FFF , 1476px 1404px #FFF , 20px 415px #FFF , 1336px 1189px #FFF , 1812px 1978px #FFF , 1125px 1079px #FFF , 523px 47px #FFF , 515px 198px #FFF , 932px 1496px #FFF , 484px 519px #FFF , 1914px 1435px #FFF , 181px 1958px #FFF , 87px 103px #FFF , 911px 1200px #FFF , 709px 360px #FFF , 1588px 601px #FFF , 1964px 709px #FFF , 1348px 36px #FFF , 938px 397px #FFF , 617px 1508px #FFF , 28px 193px #FFF , 1102px 1507px #FFF , 350px 1562px #FFF , 1347px 1130px #FFF , 1747px 1912px #FFF , 41px 1624px #FFF , 1132px 950px #FFF , 651px 280px #FFF , 528px 686px #FFF , 796px 634px #FFF , 268px 172px #FFF , 316px 1330px #FFF , 282px 246px #FFF , 1148px 975px #FFF , 939px 1625px #FFF , 894px 1699px #FFF , 1467px 477px #FFF , 587px 1010px #FFF , 249px 1727px #FFF , 194px 862px #FFF , 1644px 1984px #FFF , 1787px 167px #FFF , 1027px 1014px #FFF , 880px 538px #FFF , 214px 329px #FFF , 666px 1285px #FFF , 821px 911px #FFF , 933px 1116px #FFF , 1962px 1543px #FFF , 626px 358px #FFF , 639px 1717px #FFF , 684px 517px #FFF , 377px 1249px #FFF , 1607px 282px #FFF , 1430px 64px #FFF , 734px 479px #FFF , 1483px 1205px #FFF , 725px 1645px #FFF , 369px 1102px #FFF , 504px 1061px #FFF , 1781px 159px #FFF , 158px 112px #FFF , 1457px 348px #FFF , 224px 1845px #FFF , 288px 1825px #FFF , 1265px 259px #FFF , 1834px 274px #FFF , 1125px 1175px #FFF , 1000px 413px #FFF , 589px 1735px #FFF , 1984px 1363px #FFF , 1430px 1122px #FFF , 1350px 1546px #FFF , 133px 1628px #FFF , 1099px 1705px #FFF , 1063px 806px #FFF , 993px 1810px #FFF , 657px 76px #FFF , 825px 388px #FFF , 1826px 1709px #FFF , 400px 1603px #FFF , 678px 1545px #FFF , 411px 1643px #FFF , 704px 354px #FFF , 1487px 1570px #FFF , 511px 1856px #FFF , 1311px 97px #FFF , 1666px 1888px #FFF , 1812px 921px #FFF , 1163px 1522px #FFF , 930px 1689px #FFF , 1061px 1627px #FFF , 1318px 1328px #FFF , 775px 1787px #FFF , 1557px 1977px #FFF , 854px 579px #FFF , 1114px 1666px #FFF , 867px 1184px #FFF , 739px 561px #FFF , 1138px 1189px #FFF , 1810px 1425px #FFF , 17px 642px #FFF , 805px 204px #FFF , 1207px 569px #FFF , 976px 797px #FFF , 1786px 657px #FFF , 1915px 478px #FFF , 1895px 1432px #FFF , 695px 39px #FFF , 445px 106px #FFF , 104px 285px #FFF , 734px 1319px #FFF , 1072px 1125px #FFF , 1749px 708px #FFF , 264px 1983px #FFF , 317px 814px #FFF , 45px 1978px #FFF , 398px 120px #FFF , 1477px 726px #FFF , 1655px 614px #FFF , 934px 1475px #FFF , 346px 1843px #FFF , 291px 454px #FFF , 889px 1563px #FFF , 1114px 417px #FFF , 1993px 1178px #FFF , 345px 259px #FFF , 271px 416px #FFF , 1858px 1431px #FFF , 1332px 1068px #FFF , 1080px 646px #FFF , 30px 1378px #FFF , 1476px 1174px #FFF , 585px 1452px #FFF , 855px 1934px #FFF , 1148px 1666px #FFF , 1250px 386px #FFF , 682px 760px #FFF , 691px 162px #FFF , 1149px 1211px #FFF , 1528px 384px #FFF , 1307px 334px #FFF , 322px 1427px #FFF , 1422px 1505px #FFF , 1479px 1870px #FFF , 764px 1000px #FFF , 27px 92px #FFF , 385px 326px #FFF , 3px 1911px #FFF , 1521px 546px #FFF , 438px 658px #FFF , 1605px 1637px #FFF , 326px 198px #FFF , 999px 716px #FFF , 1559px 927px #FFF , 1757px 1298px #FFF , 334px 1472px #FFF , 650px 817px #FFF , 1094px 116px #FFF , 1063px 1822px #FFF , 1480px 831px #FFF , 676px 1556px #FFF , 1619px 618px #FFF , 125px 211px #FFF , 553px 1554px #FFF , 1778px 863px #FFF , 1079px 1074px #FFF , 952px 462px #FFF , 707px 38px #FFF , 1125px 307px #FFF , 88px 1605px #FFF , 1388px 1217px #FFF , 776px 861px #FFF , 97px 1949px #FFF , 438px 250px #FFF , 731px 556px #FFF , 41px 652px #FFF , 544px 1111px #FFF , 1944px 1951px #FFF , 1421px 758px #FFF , 694px 1908px #FFF , 914px 400px #FFF , 745px 92px #FFF , 240px 1108px #FFF , 1428px 19px #FFF , 778px 1858px #FFF , 41px 587px #FFF , 1450px 765px #FFF , 1514px 700px #FFF , 1170px 827px #FFF , 420px 81px #FFF , 974px 576px #FFF , 1637px 426px #FFF , 699px 527px #FFF , 1360px 1251px #FFF , 1118px 1339px #FFF , 1542px 1298px #FFF , 1271px 1895px #FFF , 1976px 1893px #FFF , 529px 1743px #FFF , 1195px 597px #FFF , 1116px 594px #FFF , 686px 462px #FFF , 462px 1238px #FFF , 993px 122px #FFF , 1053px 871px #FFF , 1112px 1762px #FFF , 1217px 781px #FFF , 1591px 953px #FFF , 1516px 1984px #FFF , 1475px 1596px #FFF , 1740px 821px #FFF , 1438px 1074px #FFF , 655px 864px #FFF , 290px 766px #FFF , 1051px 827px #FFF , 1523px 1260px #FFF , 1070px 729px #FFF , 1425px 1298px #FFF , 624px 55px #FFF , 234px 275px #FFF , 1577px 384px #FFF , 802px 388px #FFF , 1327px 1695px #FFF , 1079px 798px #FFF , 806px 339px #FFF , 79px 1494px #FFF , 1585px 1431px #FFF , 642px 379px #FFF , 1668px 1502px #FFF , 9px 376px #FFF , 373px 683px #FFF , 1223px 1525px #FFF , 357px 1438px #FFF , 1916px 614px #FFF , 1586px 789px #FFF , 1964px 1973px #FFF , 1133px 1023px #FFF , 388px 931px #FFF , 1008px 1247px #FFF , 496px 1833px #FFF , 1260px 1118px #FFF , 1945px 256px #FFF , 812px 1017px #FFF , 536px 1524px #FFF , 1550px 1819px #FFF , 1774px 1333px #FFF , 1115px 1429px #FFF , 1396px 675px #FFF , 81px 1883px #FFF , 863px 984px #FFF , 422px 1462px #FFF , 641px 1426px #FFF , 1587px 833px #FFF , 1697px 1489px #FFF , 1043px 1566px #FFF , 197px 544px #FFF , 1098px 1442px #FFF , 1832px 1396px #FFF , 247px 1225px #FFF , 494px 766px #FFF , 437px 1162px #FFF , 1590px 1264px #FFF , 1672px 1977px #FFF , 1710px 136px #FFF , 1209px 936px #FFF , 1260px 264px #FFF , 117px 863px #FFF , 795px 1420px #FFF , 84px 81px #FFF , 1493px 378px #FFF , 1533px 1281px #FFF , 199px 1398px #FFF , 960px 1515px #FFF , 193px 266px #FFF , 694px 399px #FFF , 1298px 297px #FFF , 1139px 1379px #FFF , 568px 157px #FFF , 380px 877px #FFF , 1670px 515px #FFF , 1304px 80px #FFF , 602px 1160px #FFF , 991px 824px #FFF , 361px 572px #FFF , 1216px 709px #FFF , 1128px 198px #FFF , 191px 146px #FFF , 700px 1921px #FFF , 699px 1727px #FFF , 674px 986px #FFF , 166px 721px #FFF , 204px 265px #FFF , 856px 1329px #FFF , 1662px 1559px #FFF , 360px 908px #FFF , 1313px 1722px #FFF , 1780px 245px #FFF , 1433px 1242px #FFF , 1892px 1433px #FFF , 1323px 1805px #FFF , 295px 1555px #FFF , 564px 133px #FFF , 919px 1841px #FFF , 1352px 54px #FFF , 1885px 135px #FFF , 277px 1739px #FFF , 776px 1592px #FFF , 992px 1589px #FFF , 1073px 1027px #FFF , 842px 226px #FFF , 1193px 628px #FFF , 879px 1899px #FFF , 802px 1413px #FFF , 1417px 1335px #FFF , 348px 1318px #FFF , 724px 935px #FFF , 306px 559px #FFF , 1389px 1210px #FFF , 1085px 1449px #FFF , 1718px 1967px #FFF , 683px 1159px #FFF , 293px 1188px #FFF , 628px 476px #FFF , 652px 733px #FFF , 1936px 866px #FFF , 1903px 1011px #FFF , 977px 1294px #FFF , 346px 1401px #FFF , 864px 1013px #FFF , 1769px 107px #FFF , 1982px 1176px #FFF , 1867px 143px #FFF , 1997px 1582px #FFF , 1476px 593px #FFF , 128px 285px #FFF , 1140px 58px #FFF , 1026px 1972px #FFF , 1859px 1974px #FFF , 922px 64px #FFF , 1712px 582px #FFF , 1076px 638px #FFF , 362px 105px #FFF , 120px 83px #FFF , 610px 359px #FFF , 511px 456px #FFF , 1476px 602px #FFF , 269px 1775px #FFF , 272px 1625px #FFF , 162px 1864px #FFF , 1237px 817px #FFF , 1939px 507px #FFF , 1821px 1741px #FFF , 1603px 1234px #FFF , 562px 80px #FFF , 106px 880px #FFF , 1701px 586px #FFF , 1422px 908px #FFF , 1802px 1966px #FFF , 459px 1648px #FFF , 612px 1599px #FFF , 323px 1672px #FFF , 320px 716px #FFF , 807px 1441px #FFF , 1367px 1731px #FFF , 1501px 1379px #FFF , 1980px 1548px #FFF , 743px 747px #FFF , 1965px 951px #FFF , 1717px 697px #FFF , 1447px 1703px #FFF , 1100px 869px #FFF , 943px 1232px #FFF , 279px 1655px #FFF , 1428px 1289px #FFF , 365px 1825px #FFF , 1951px 526px #FFF , 1166px 1068px #FFF , 1802px 456px #FFF , 57px 381px #FFF , 837px 852px #FFF , 1114px 467px #FFF , 1007px 1832px #FFF , 174px 1221px #FFF , 195px 188px #FFF , 1823px 438px #FFF , 984px 917px #FFF , 1424px 530px #FFF , 272px 244px #FFF , 1386px 1239px #FFF , 4px 1442px #FFF , 1129px 1376px #FFF , 265px 1527px #FFF , 1003px 718px #FFF , 993px 75px #FFF , 1820px 1655px #FFF , 758px 282px #FFF , 934px 1108px #FFF , 1492px 1687px #FFF , 1245px 1344px #FFF , 110px 1810px #FFF , 1988px 1713px #FFF , 1386px 1883px #FFF , 1781px 1461px #FFF , 361px 563px #FFF , 474px 1150px #FFF , 185px 1218px #FFF , 793px 1513px #FFF , 1474px 1117px #FFF , 221px 295px #FFF , 1445px 1859px #FFF , 903px 972px #FFF , 1420px 139px #FFF , 1477px 1084px #FFF , 373px 1554px #FFF , 1355px 1247px #FFF , 1483px 48px #FFF , 158px 1684px #FFF , 145px 963px #FFF , 213px 841px #FFF , 634px 17px #FFF , 128px 1911px #FFF , 1711px 1125px #FFF , 906px 1253px #FFF , 1158px 433px #FFF , 1544px 1045px #FFF , 506px 1388px #FFF , 1261px 1555px #FFF , 876px 286px #FFF , 1042px 815px #FFF , 1870px 715px #FFF , 808px 1262px #FFF , 1777px 1838px #FFF , 470px 953px #FFF , 99px 469px #FFF , 1631px 896px #FFF , 676px 1877px #FFF , 805px 324px #FFF , 1966px 1784px #FFF , 893px 520px #FFF , 738px 1217px #FFF , 1064px 39px #FFF , 1284px 351px #FFF , 626px 1902px #FFF , 1272px 1574px #FFF , 62px 1290px #FFF , 43px 1931px #FFF , 449px 1603px #FFF , 442px 1841px #FFF , 933px 1952px #FFF , 1120px 311px #FFF , 1800px 1824px #FFF , 1736px 1738px #FFF , 1656px 3px #FFF , 1709px 359px #FFF , 559px 42px #FFF , 1404px 730px #FFF , 356px 179px #FFF , 1267px 1929px #FFF , 1629px 1547px #FFF , 115px 957px #FFF , 336px 1565px #FFF , 1727px 232px #FFF , 578px 1538px #FFF , 148px 161px #FFF , 704px 722px #FFF , 1331px 1899px #FFF , 571px 241px #FFF , 386px 810px #FFF , 934px 622px #FFF , 1006px 838px #FFF , 117px 1847px #FFF , 1850px 583px #FFF , 355px 258px #FFF , 1715px 144px #FFF , 1763px 1679px #FFF , 1072px 374px #FFF , 237px 1190px #FFF , 1034px 571px #FFF , 321px 1904px #FFF , 1732px 743px #FFF , 1352px 530px #FFF , 1260px 1611px #FFF , 1930px 192px #FFF , 1660px 611px #FFF , 163px 1627px #FFF , 311px 451px #FFF , 64px 180px #FFF , 193px 1528px #FFF , 1630px 687px #FFF , 1804px 577px #FFF , 786px 1702px #FFF , 1568px 127px #FFF , 817px 1712px #FFF , 1493px 647px #FFF , 266px 22px #FFF , 191px 1177px #FFF , 1408px 106px #FFF , 1257px 534px #FFF , 1040px 1282px #FFF , 1148px 1123px #FFF , 826px 1128px #FFF , 1406px 76px #FFF , 1835px 1071px #FFF , 1809px 1183px #FFF , 428px 866px #FFF , 1425px 1402px #FFF , 783px 896px #FFF , 987px 436px #FFF , 1452px 144px #FFF , 485px 1760px #FFF , 1678px 721px #FFF , 6px 1929px #FFF , 1629px 1544px #FFF , 1588px 21px #FFF , 1567px 485px #FFF , 442px 590px #FFF , 1232px 648px #FFF , 1397px 1949px #FFF , 1819px 651px #FFF , 467px 1636px #FFF , 1297px 1216px #FFF , 1743px 20px #FFF , 1264px 1242px #FFF , 116px 420px #FFF , 90px 721px #FFF , 470px 1939px #FFF , 816px 87px #FFF , 88px 1021px #FFF , 1593px 789px #FFF , 283px 36px #FFF , 775px 1722px #FFF , 1643px 1554px #FFF , 969px 389px #FFF , 467px 1442px #FFF , 1441px 1731px #FFF , 168px 1285px #FFF , 1553px 1056px #FFF , 1930px 777px #FFF , 1626px 915px #FFF , 1678px 1019px #FFF , 1739px 280px #FFF , 297px 1134px #FFF , 1477px 1896px #FFF , 1673px 1215px #FFF , 1629px 835px #FFF , 1024px 1875px #FFF , 1452px 437px #FFF , 850px 662px #FFF , 575px 257px #FFF , 1954px 1919px #FFF , 1985px 269px #FFF , 482px 701px #FFF , 1712px 339px #FFF , 1451px 665px #FFF , 1740px 16px #FFF , 1591px 13px #FFF , 1449px 30px #FFF , 18px 1715px #FFF , 370px 450px #FFF , 374px 917px #FFF , 1945px 1726px #FFF , 1086px 1134px #FFF , 323px 1135px #FFF , 1912px 1212px #FFF;
-          animation: animStar 50s linear infinite;
+      .logo {
+        width: 160px;
       }
-      #stars:after {
-          content: " ";
-          position: absolute;
-          top: 2000px;
-          width: 1px;
-          height: 1px;
-          background: transparent;
-          box-shadow: 640px 1696px #FFF , 1160px 1058px #FFF , 1227px 156px #FFF , 1138px 1418px #FFF , 1727px 329px #FFF , 37px 279px #FFF , 1417px 1804px #FFF , 1837px 1261px #FFF , 856px 1149px #FFF , 43px 510px #FFF , 1140px 520px #FFF , 1356px 354px #FFF , 479px 1893px #FFF , 117px 1184px #FFF , 1637px 653px #FFF , 1079px 1938px #FFF , 987px 484px #FFF , 1574px 465px #FFF , 1961px 1762px #FFF , 738px 418px #FFF , 51px 1272px #FFF , 158px 859px #FFF , 1797px 503px #FFF , 83px 253px #FFF , 592px 1108px #FFF , 1832px 392px #FFF , 679px 1536px #FFF , 703px 1941px #FFF , 1932px 770px #FFF , 1755px 802px #FFF , 1643px 1784px #FFF , 1967px 163px #FFF , 1063px 1983px #FFF , 1509px 880px #FFF , 1891px 651px #FFF , 1832px 1644px #FFF , 1260px 638px #FFF , 453px 450px #FFF , 1977px 1782px #FFF , 208px 1856px #FFF , 1941px 1343px #FFF , 894px 872px #FFF , 936px 1444px #FFF , 503px 438px #FFF , 118px 1556px #FFF , 1591px 883px #FFF , 940px 1674px #FFF , 76px 1676px #FFF , 528px 938px #FFF , 772px 359px #FFF , 1934px 731px #FFF , 1787px 72px #FFF , 1445px 780px #FFF , 677px 1306px #FFF , 1021px 900px #FFF , 199px 343px #FFF , 1194px 1524px #FFF , 75px 1700px #FFF , 1323px 1400px #FFF , 712px 1806px #FFF , 136px 803px #FFF , 842px 299px #FFF , 138px 570px #FFF , 245px 975px #FFF , 1305px 1210px #FFF , 1615px 164px #FFF , 1710px 568px #FFF , 494px 397px #FFF , 598px 286px #FFF , 887px 1775px #FFF , 293px 1063px #FFF , 189px 49px #FFF , 1275px 199px #FFF , 693px 1163px #FFF , 1186px 322px #FFF , 527px 807px #FFF , 1412px 1246px #FFF , 1397px 843px #FFF , 1860px 480px #FFF , 847px 777px #FFF , 431px 917px #FFF , 487px 1662px #FFF , 1226px 1930px #FFF , 1109px 987px #FFF , 1110px 162px #FFF , 486px 1510px #FFF , 1364px 1018px #FFF , 255px 1488px #FFF , 1960px 1688px #FFF , 457px 1263px #FFF , 1202px 502px #FFF , 1206px 1974px #FFF , 1130px 1127px #FFF , 1164px 383px #FFF , 893px 1646px #FFF , 1575px 1292px #FFF , 600px 1489px #FFF , 348px 591px #FFF , 915px 1754px #FFF , 825px 757px #FFF , 379px 1727px #FFF , 573px 1729px #FFF , 1555px 1569px #FFF , 293px 512px #FFF , 1743px 470px #FFF , 1872px 1789px #FFF , 1535px 564px #FFF , 732px 92px #FFF , 1114px 777px #FFF , 1655px 1514px #FFF , 1781px 1308px #FFF , 1204px 1545px #FFF , 1068px 895px #FFF , 1956px 275px #FFF , 157px 1972px #FFF , 189px 254px #FFF , 1644px 65px #FFF , 324px 1851px #FFF , 54px 588px #FFF , 1183px 1600px #FFF , 1781px 1990px #FFF , 1403px 781px #FFF , 55px 102px #FFF , 335px 1225px #FFF , 934px 1000px #FFF , 642px 1489px #FFF , 430px 170px #FFF , 1708px 1737px #FFF , 563px 1802px #FFF , 702px 1114px #FFF , 1821px 487px #FFF , 1874px 267px #FFF , 466px 305px #FFF , 1622px 1459px #FFF , 50px 1693px #FFF , 1320px 64px #FFF , 1476px 1404px #FFF , 20px 415px #FFF , 1336px 1189px #FFF , 1812px 1978px #FFF , 1125px 1079px #FFF , 523px 47px #FFF , 515px 198px #FFF , 932px 1496px #FFF , 484px 519px #FFF , 1914px 1435px #FFF , 181px 1958px #FFF , 87px 103px #FFF , 911px 1200px #FFF , 709px 360px #FFF , 1588px 601px #FFF , 1964px 709px #FFF , 1348px 36px #FFF , 938px 397px #FFF , 617px 1508px #FFF , 28px 193px #FFF , 1102px 1507px #FFF , 350px 1562px #FFF , 1347px 1130px #FFF , 1747px 1912px #FFF , 41px 1624px #FFF , 1132px 950px #FFF , 651px 280px #FFF , 528px 686px #FFF , 796px 634px #FFF , 268px 172px #FFF , 316px 1330px #FFF , 282px 246px #FFF , 1148px 975px #FFF , 939px 1625px #FFF , 894px 1699px #FFF , 1467px 477px #FFF , 587px 1010px #FFF , 249px 1727px #FFF , 194px 862px #FFF , 1644px 1984px #FFF , 1787px 167px #FFF , 1027px 1014px #FFF , 880px 538px #FFF , 214px 329px #FFF , 666px 1285px #FFF , 821px 911px #FFF , 933px 1116px #FFF , 1962px 1543px #FFF , 626px 358px #FFF , 639px 1717px #FFF , 684px 517px #FFF , 377px 1249px #FFF , 1607px 282px #FFF , 1430px 64px #FFF , 734px 479px #FFF , 1483px 1205px #FFF , 725px 1645px #FFF , 369px 1102px #FFF , 504px 1061px #FFF , 1781px 159px #FFF , 158px 112px #FFF , 1457px 348px #FFF , 224px 1845px #FFF , 288px 1825px #FFF , 1265px 259px #FFF , 1834px 274px #FFF , 1125px 1175px #FFF , 1000px 413px #FFF , 589px 1735px #FFF , 1984px 1363px #FFF , 1430px 1122px #FFF , 1350px 1546px #FFF , 133px 1628px #FFF , 1099px 1705px #FFF , 1063px 806px #FFF , 993px 1810px #FFF , 657px 76px #FFF , 825px 388px #FFF , 1826px 1709px #FFF , 400px 1603px #FFF , 678px 1545px #FFF , 411px 1643px #FFF , 704px 354px #FFF , 1487px 1570px #FFF , 511px 1856px #FFF , 1311px 97px #FFF , 1666px 1888px #FFF , 1812px 921px #FFF , 1163px 1522px #FFF , 930px 1689px #FFF , 1061px 1627px #FFF , 1318px 1328px #FFF , 775px 1787px #FFF , 1557px 1977px #FFF , 854px 579px #FFF , 1114px 1666px #FFF , 867px 1184px #FFF , 739px 561px #FFF , 1138px 1189px #FFF , 1810px 1425px #FFF , 17px 642px #FFF , 805px 204px #FFF , 1207px 569px #FFF , 976px 797px #FFF , 1786px 657px #FFF , 1915px 478px #FFF , 1895px 1432px #FFF , 695px 39px #FFF , 445px 106px #FFF , 104px 285px #FFF , 734px 1319px #FFF , 1072px 1125px #FFF , 1749px 708px #FFF , 264px 1983px #FFF , 317px 814px #FFF , 45px 1978px #FFF , 398px 120px #FFF , 1477px 726px #FFF , 1655px 614px #FFF , 934px 1475px #FFF , 346px 1843px #FFF , 291px 454px #FFF , 889px 1563px #FFF , 1114px 417px #FFF , 1993px 1178px #FFF , 345px 259px #FFF , 271px 416px #FFF , 1858px 1431px #FFF , 1332px 1068px #FFF , 1080px 646px #FFF , 30px 1378px #FFF , 1476px 1174px #FFF , 585px 1452px #FFF , 855px 1934px #FFF , 1148px 1666px #FFF , 1250px 386px #FFF , 682px 760px #FFF , 691px 162px #FFF , 1149px 1211px #FFF , 1528px 384px #FFF , 1307px 334px #FFF , 322px 1427px #FFF , 1422px 1505px #FFF , 1479px 1870px #FFF , 764px 1000px #FFF , 27px 92px #FFF , 385px 326px #FFF , 3px 1911px #FFF , 1521px 546px #FFF , 438px 658px #FFF , 1605px 1637px #FFF , 326px 198px #FFF , 999px 716px #FFF , 1559px 927px #FFF , 1757px 1298px #FFF , 334px 1472px #FFF , 650px 817px #FFF , 1094px 116px #FFF , 1063px 1822px #FFF , 1480px 831px #FFF , 676px 1556px #FFF , 1619px 618px #FFF , 125px 211px #FFF , 553px 1554px #FFF , 1778px 863px #FFF , 1079px 1074px #FFF , 952px 462px #FFF , 707px 38px #FFF , 1125px 307px #FFF , 88px 1605px #FFF , 1388px 1217px #FFF , 776px 861px #FFF , 97px 1949px #FFF , 438px 250px #FFF , 731px 556px #FFF , 41px 652px #FFF , 544px 1111px #FFF , 1944px 1951px #FFF , 1421px 758px #FFF , 694px 1908px #FFF , 914px 400px #FFF , 745px 92px #FFF , 240px 1108px #FFF , 1428px 19px #FFF , 778px 1858px #FFF , 41px 587px #FFF , 1450px 765px #FFF , 1514px 700px #FFF , 1170px 827px #FFF , 420px 81px #FFF , 974px 576px #FFF , 1637px 426px #FFF , 699px 527px #FFF , 1360px 1251px #FFF , 1118px 1339px #FFF , 1542px 1298px #FFF , 1271px 1895px #FFF , 1976px 1893px #FFF , 529px 1743px #FFF , 1195px 597px #FFF , 1116px 594px #FFF , 686px 462px #FFF , 462px 1238px #FFF , 993px 122px #FFF , 1053px 871px #FFF , 1112px 1762px #FFF , 1217px 781px #FFF , 1591px 953px #FFF , 1516px 1984px #FFF , 1475px 1596px #FFF , 1740px 821px #FFF , 1438px 1074px #FFF , 655px 864px #FFF , 290px 766px #FFF , 1051px 827px #FFF , 1523px 1260px #FFF , 1070px 729px #FFF , 1425px 1298px #FFF , 624px 55px #FFF , 234px 275px #FFF , 1577px 384px #FFF , 802px 388px #FFF , 1327px 1695px #FFF , 1079px 798px #FFF , 806px 339px #FFF , 79px 1494px #FFF , 1585px 1431px #FFF , 642px 379px #FFF , 1668px 1502px #FFF , 9px 376px #FFF , 373px 683px #FFF , 1223px 1525px #FFF , 357px 1438px #FFF , 1916px 614px #FFF , 1586px 789px #FFF , 1964px 1973px #FFF , 1133px 1023px #FFF , 388px 931px #FFF , 1008px 1247px #FFF , 496px 1833px #FFF , 1260px 1118px #FFF , 1945px 256px #FFF , 812px 1017px #FFF , 536px 1524px #FFF , 1550px 1819px #FFF , 1774px 1333px #FFF , 1115px 1429px #FFF , 1396px 675px #FFF , 81px 1883px #FFF , 863px 984px #FFF , 422px 1462px #FFF , 641px 1426px #FFF , 1587px 833px #FFF , 1697px 1489px #FFF , 1043px 1566px #FFF , 197px 544px #FFF , 1098px 1442px #FFF , 1832px 1396px #FFF , 247px 1225px #FFF , 494px 766px #FFF , 437px 1162px #FFF , 1590px 1264px #FFF , 1672px 1977px #FFF , 1710px 136px #FFF , 1209px 936px #FFF , 1260px 264px #FFF , 117px 863px #FFF , 795px 1420px #FFF , 84px 81px #FFF , 1493px 378px #FFF , 1533px 1281px #FFF , 199px 1398px #FFF , 960px 1515px #FFF , 193px 266px #FFF , 694px 399px #FFF , 1298px 297px #FFF , 1139px 1379px #FFF , 568px 157px #FFF , 380px 877px #FFF , 1670px 515px #FFF , 1304px 80px #FFF , 602px 1160px #FFF , 991px 824px #FFF , 361px 572px #FFF , 1216px 709px #FFF , 1128px 198px #FFF , 191px 146px #FFF , 700px 1921px #FFF , 699px 1727px #FFF , 674px 986px #FFF , 166px 721px #FFF , 204px 265px #FFF , 856px 1329px #FFF , 1662px 1559px #FFF , 360px 908px #FFF , 1313px 1722px #FFF , 1780px 245px #FFF , 1433px 1242px #FFF , 1892px 1433px #FFF , 1323px 1805px #FFF , 295px 1555px #FFF , 564px 133px #FFF , 919px 1841px #FFF , 1352px 54px #FFF , 1885px 135px #FFF , 277px 1739px #FFF , 776px 1592px #FFF , 992px 1589px #FFF , 1073px 1027px #FFF , 842px 226px #FFF , 1193px 628px #FFF , 879px 1899px #FFF , 802px 1413px #FFF , 1417px 1335px #FFF , 348px 1318px #FFF , 724px 935px #FFF , 306px 559px #FFF , 1389px 1210px #FFF , 1085px 1449px #FFF , 1718px 1967px #FFF , 683px 1159px #FFF , 293px 1188px #FFF , 628px 476px #FFF , 652px 733px #FFF , 1936px 866px #FFF , 1903px 1011px #FFF , 977px 1294px #FFF , 346px 1401px #FFF , 864px 1013px #FFF , 1769px 107px #FFF , 1982px 1176px #FFF , 1867px 143px #FFF , 1997px 1582px #FFF , 1476px 593px #FFF , 128px 285px #FFF , 1140px 58px #FFF , 1026px 1972px #FFF , 1859px 1974px #FFF , 922px 64px #FFF , 1712px 582px #FFF , 1076px 638px #FFF , 362px 105px #FFF , 120px 83px #FFF , 610px 359px #FFF , 511px 456px #FFF , 1476px 602px #FFF , 269px 1775px #FFF , 272px 1625px #FFF , 162px 1864px #FFF , 1237px 817px #FFF , 1939px 507px #FFF , 1821px 1741px #FFF , 1603px 1234px #FFF , 562px 80px #FFF , 106px 880px #FFF , 1701px 586px #FFF , 1422px 908px #FFF , 1802px 1966px #FFF , 459px 1648px #FFF , 612px 1599px #FFF , 323px 1672px #FFF , 320px 716px #FFF , 807px 1441px #FFF , 1367px 1731px #FFF , 1501px 1379px #FFF , 1980px 1548px #FFF , 743px 747px #FFF , 1965px 951px #FFF , 1717px 697px #FFF , 1447px 1703px #FFF , 1100px 869px #FFF , 943px 1232px #FFF , 279px 1655px #FFF , 1428px 1289px #FFF , 365px 1825px #FFF , 1951px 526px #FFF , 1166px 1068px #FFF , 1802px 456px #FFF , 57px 381px #FFF , 837px 852px #FFF , 1114px 467px #FFF , 1007px 1832px #FFF , 174px 1221px #FFF , 195px 188px #FFF , 1823px 438px #FFF , 984px 917px #FFF , 1424px 530px #FFF , 272px 244px #FFF , 1386px 1239px #FFF , 4px 1442px #FFF , 1129px 1376px #FFF , 265px 1527px #FFF , 1003px 718px #FFF , 993px 75px #FFF , 1820px 1655px #FFF , 758px 282px #FFF , 934px 1108px #FFF , 1492px 1687px #FFF , 1245px 1344px #FFF , 110px 1810px #FFF , 1988px 1713px #FFF , 1386px 1883px #FFF , 1781px 1461px #FFF , 361px 563px #FFF , 474px 1150px #FFF , 185px 1218px #FFF , 793px 1513px #FFF , 1474px 1117px #FFF , 221px 295px #FFF , 1445px 1859px #FFF , 903px 972px #FFF , 1420px 139px #FFF , 1477px 1084px #FFF , 373px 1554px #FFF , 1355px 1247px #FFF , 1483px 48px #FFF , 158px 1684px #FFF , 145px 963px #FFF , 213px 841px #FFF , 634px 17px #FFF , 128px 1911px #FFF , 1711px 1125px #FFF , 906px 1253px #FFF , 1158px 433px #FFF , 1544px 1045px #FFF , 506px 1388px #FFF , 1261px 1555px #FFF , 876px 286px #FFF , 1042px 815px #FFF , 1870px 715px #FFF , 808px 1262px #FFF , 1777px 1838px #FFF , 470px 953px #FFF , 99px 469px #FFF , 1631px 896px #FFF , 676px 1877px #FFF , 805px 324px #FFF , 1966px 1784px #FFF , 893px 520px #FFF , 738px 1217px #FFF , 1064px 39px #FFF , 1284px 351px #FFF , 626px 1902px #FFF , 1272px 1574px #FFF , 62px 1290px #FFF , 43px 1931px #FFF , 449px 1603px #FFF , 442px 1841px #FFF , 933px 1952px #FFF , 1120px 311px #FFF , 1800px 1824px #FFF , 1736px 1738px #FFF , 1656px 3px #FFF , 1709px 359px #FFF , 559px 42px #FFF , 1404px 730px #FFF , 356px 179px #FFF , 1267px 1929px #FFF , 1629px 1547px #FFF , 115px 957px #FFF , 336px 1565px #FFF , 1727px 232px #FFF , 578px 1538px #FFF , 148px 161px #FFF , 704px 722px #FFF , 1331px 1899px #FFF , 571px 241px #FFF , 386px 810px #FFF , 934px 622px #FFF , 1006px 838px #FFF , 117px 1847px #FFF , 1850px 583px #FFF , 355px 258px #FFF , 1715px 144px #FFF , 1763px 1679px #FFF , 1072px 374px #FFF , 237px 1190px #FFF , 1034px 571px #FFF , 321px 1904px #FFF , 1732px 743px #FFF , 1352px 530px #FFF , 1260px 1611px #FFF , 1930px 192px #FFF , 1660px 611px #FFF , 163px 1627px #FFF , 311px 451px #FFF , 64px 180px #FFF , 193px 1528px #FFF , 1630px 687px #FFF , 1804px 577px #FFF , 786px 1702px #FFF , 1568px 127px #FFF , 817px 1712px #FFF , 1493px 647px #FFF , 266px 22px #FFF , 191px 1177px #FFF , 1408px 106px #FFF , 1257px 534px #FFF , 1040px 1282px #FFF , 1148px 1123px #FFF , 826px 1128px #FFF , 1406px 76px #FFF , 1835px 1071px #FFF , 1809px 1183px #FFF , 428px 866px #FFF , 1425px 1402px #FFF , 783px 896px #FFF , 987px 436px #FFF , 1452px 144px #FFF , 485px 1760px #FFF , 1678px 721px #FFF , 6px 1929px #FFF , 1629px 1544px #FFF , 1588px 21px #FFF , 1567px 485px #FFF , 442px 590px #FFF , 1232px 648px #FFF , 1397px 1949px #FFF , 1819px 651px #FFF , 467px 1636px #FFF , 1297px 1216px #FFF , 1743px 20px #FFF , 1264px 1242px #FFF , 116px 420px #FFF , 90px 721px #FFF , 470px 1939px #FFF , 816px 87px #FFF , 88px 1021px #FFF , 1593px 789px #FFF , 283px 36px #FFF , 775px 1722px #FFF , 1643px 1554px #FFF , 969px 389px #FFF , 467px 1442px #FFF , 1441px 1731px #FFF , 168px 1285px #FFF , 1553px 1056px #FFF , 1930px 777px #FFF , 1626px 915px #FFF , 1678px 1019px #FFF , 1739px 280px #FFF , 297px 1134px #FFF , 1477px 1896px #FFF , 1673px 1215px #FFF , 1629px 835px #FFF , 1024px 1875px #FFF , 1452px 437px #FFF , 850px 662px #FFF , 575px 257px #FFF , 1954px 1919px #FFF , 1985px 269px #FFF , 482px 701px #FFF , 1712px 339px #FFF , 1451px 665px #FFF , 1740px 16px #FFF , 1591px 13px #FFF , 1449px 30px #FFF , 18px 1715px #FFF , 370px 450px #FFF , 374px 917px #FFF , 1945px 1726px #FFF , 1086px 1134px #FFF , 323px 1135px #FFF , 1912px 1212px #FFF;
-      }
+    }
+  </style>
+</head>
+<body>
+  <div class="container">
+    <div class="card">
+      <svg class="logo" viewBox="60 0 2380 790" xmlns="http://www.w3.org/2000/svg">
+        <path class="wordmark" d="M70.6,768.3V739.6H103q25.95,0,41.3-19.3t15.3-52.5V182.2C159,166,150.9,158,135.4,158H70.6V129.2H245.4L551.8,621.6V228.4q0-32.55-15.3-51.6c-10.2-12.6-23.6-19-40.4-19H463.8V129.2H677.4v28.7H645.1c-16.8,0-30.5,6.4-41.3,19.3s-16.2,30.4-16.2,52.5V784.4H551.7L199,227.1h-3.6V667.8c0,22.1,5.2,39.7,15.7,52.5s24.1,19.3,40.8,19.3h32.3v28.7Z"/>
+        <path class="wordmark" d="M1637.9,784.5,1429.6,197.2c-5.4-14.8-12.3-25.1-20.6-30.7s-19.2-8.5-32.3-8.5h-56.5V129.2h285.5v28.7h-59.2c-8.4,0-15.6,2.3-21.5,6.8s-8.9,9.8-8.9,15.8a60.49,60.49,0,0,0,3.5,19.9l154.2,432.8,119.6-365.5c7-22.2,10.6-43.2,10.6-63,0-12.6-3.7-23.5-11.1-32.8s-18.9-14-34.4-14H1710V129.2h241.4v28.7H1918q-53.85,0-75.4,65.5l-182.2,561h-22.5Z"/>
+        <path class="wordmark" d="M1806.3,768.3V739.6h33.2q52.05,0,75.4-65.5l194.7-544.9H2132l194.8,570.9c10.8,26.3,28.7,39.5,53.9,39.5H2431v28.7H2152.6V739.6h59.2c9,0,16.5-2.2,22.4-6.7s9-9.7,9-15.7c0-7.8-1.2-14.3-3.6-19.7l-39.5-117.6H1998.8l-21.5,60.5q-14,35.1-13.9,52.7a51.49,51.49,0,0,0,11,32.5c7.3,9.4,19.4,14.1,36.1,14.1h47.6v28.7H1806.3Zm204.5-220.8h177.4L2098,284.9Z"/>
+        <path class="wordmark" d="M1132.5,768c-4.3.2-8.7.3-13.1.3-162.5,0-294.2-131.7-294.2-294.2a293.38,293.38,0,0,1,9.3-73.6l61-61.4,5.7,47.6a268.11,268.11,0,0,0-24.9,113C876.3,643.9,989.9,761.5,1132.5,768Z"/>
+        <path class="wordmark" d="M1413.6,474.1c0,4.4-.1,8.8-.3,13.1-6.5-142.5-124.2-256.1-268.3-256.1a267,267,0,0,0-129.5,33.2L967.6,262l57.9-66.8a294.75,294.75,0,0,1,93.9-15.3C1281.8,179.9,1413.6,311.6,1413.6,474.1Z"/>
+        <polygon class="mark" points="649.6 572 903.1 316.9 922.8 480.7 931.3 318.5 1207.1 555.3 949.6 297.8 1106.7 278.9 946 271.3 1181.1 0 927.7 252.4 908.2 90.4 900.6 253.5 628.5 18.7 884 274.2 719.8 293.1 882.3 300.8 649.6 572"/>
+      </svg>
 
-      #stars2 {
-          width: 2px;
-          height: 2px;
-          background: transparent;
-          box-shadow: 1525px 16px #FFF , 800px 1234px #FFF , 772px 1261px #FFF , 1350px 1211px #FFF , 1179px 1382px #FFF , 1593px 1378px #FFF , 385px 1199px #FFF , 123px 1615px #FFF , 225px 1069px #FFF , 76px 1610px #FFF , 545px 465px #FFF , 1871px 1565px #FFF , 931px 1475px #FFF , 288px 484px #FFF , 1168px 1634px #FFF , 1132px 582px #FFF , 266px 551px #FFF , 958px 1243px #FFF , 604px 1196px #FFF , 1847px 1135px #FFF , 182px 1150px #FFF , 643px 207px #FFF , 195px 1950px #FFF , 901px 1346px #FFF , 1121px 378px #FFF , 1859px 845px #FFF , 718px 1223px #FFF , 1014px 638px #FFF , 1525px 534px #FFF , 903px 1689px #FFF , 798px 66px #FFF , 1499px 806px #FFF , 503px 467px #FFF , 996px 739px #FFF , 1234px 1701px #FFF , 613px 1915px #FFF , 1070px 969px #FFF , 959px 1300px #FFF , 480px 527px #FFF , 302px 1658px #FFF , 284px 1466px #FFF , 1265px 1031px #FFF , 1903px 683px #FFF , 601px 56px #FFF , 1133px 1681px #FFF , 849px 177px #FFF , 872px 102px #FFF , 1577px 1281px #FFF , 1356px 1958px #FFF , 1553px 1340px #FFF , 262px 987px #FFF , 787px 1684px #FFF , 154px 194px #FFF , 172px 1278px #FFF , 1384px 148px #FFF , 400px 582px #FFF , 1998px 1227px #FFF , 1730px 162px #FFF , 688px 31px #FFF , 983px 1472px #FFF , 1576px 324px #FFF , 183px 1006px #FFF , 158px 801px #FFF , 1955px 1115px #FFF , 1702px 1695px #FFF , 917px 1701px #FFF , 745px 1862px #FFF , 1129px 1315px #FFF , 890px 446px #FFF , 992px 1626px #FFF , 1017px 1228px #FFF , 188px 574px #FFF , 1649px 939px #FFF , 899px 568px #FFF , 353px 1003px #FFF , 1367px 1696px #FFF , 1532px 753px #FFF , 699px 1190px #FFF , 753px 1566px #FFF , 69px 159px #FFF , 19px 830px #FFF , 570px 351px #FFF , 364px 1947px #FFF , 1042px 198px #FFF , 668px 184px #FFF , 1551px 152px #FFF , 796px 1433px #FFF , 1043px 917px #FFF , 1449px 946px #FFF , 1617px 934px #FFF , 32px 657px #FFF , 491px 1236px #FFF , 658px 1052px #FFF , 715px 1937px #FFF , 452px 284px #FFF , 1521px 35px #FFF , 228px 733px #FFF , 1652px 372px #FFF , 1976px 633px #FFF , 1700px 1554px #FFF , 237px 1762px #FFF , 1929px 1487px #FFF , 1242px 1234px #FFF , 1794px 1405px #FFF , 456px 709px #FFF , 862px 1221px #FFF , 1674px 28px #FFF , 1255px 332px #FFF , 1841px 170px #FFF , 1075px 193px #FFF , 149px 962px #FFF , 741px 1520px #FFF , 1379px 544px #FFF , 1091px 1231px #FFF , 1364px 1157px #FFF , 1879px 720px #FFF , 462px 13px #FFF , 420px 305px #FFF , 574px 835px #FFF , 575px 426px #FFF , 1208px 816px #FFF , 743px 1122px #FFF , 1847px 230px #FFF , 450px 1644px #FFF , 1688px 1409px #FFF , 453px 1959px #FFF , 1661px 917px #FFF , 1236px 1313px #FFF , 98px 299px #FFF , 1372px 676px #FFF , 1209px 320px #FFF , 1523px 371px #FFF , 1947px 1930px #FFF , 36px 1499px #FFF , 66px 1418px #FFF , 581px 1642px #FFF , 1225px 1664px #FFF , 1764px 566px #FFF , 656px 1009px #FFF , 1155px 641px #FFF , 1275px 1534px #FFF , 1822px 1593px #FFF , 1798px 1283px #FFF , 994px 1852px #FFF , 1933px 31px #FFF , 1247px 1459px #FFF , 1148px 669px #FFF , 455px 262px #FFF , 1319px 1419px #FFF , 1637px 1307px #FFF , 147px 1499px #FFF , 1372px 1796px #FFF , 1973px 1616px #FFF , 1491px 251px #FFF , 72px 158px #FFF , 1519px 878px #FFF , 13px 955px #FFF , 1120px 1225px #FFF , 767px 1873px #FFF , 475px 1980px #FFF , 221px 1803px #FFF , 654px 623px #FFF , 982px 285px #FFF , 1856px 1165px #FFF , 1533px 944px #FFF , 937px 1457px #FFF , 1935px 664px #FFF , 1793px 292px #FFF , 858px 1983px #FFF , 390px 398px #FFF , 1313px 1297px #FFF , 725px 1096px #FFF , 1469px 1658px #FFF , 648px 1141px #FFF , 953px 255px #FFF , 286px 346px #FFF , 32px 1662px #FFF , 1272px 316px #FFF , 1252px 710px #FFF , 1337px 1505px #FFF , 565px 1464px #FFF , 1116px 506px #FFF , 1593px 163px #FFF , 214px 1048px #FFF , 1195px 1475px #FFF , 1384px 1765px #FFF , 706px 988px #FFF , 283px 1279px #FFF , 737px 1052px #FFF , 381px 1420px #FFF , 1630px 610px #FFF , 938px 693px #FFF , 1721px 1096px #FFF , 1210px 341px #FFF , 906px 1940px #FFF , 1007px 650px #FFF , 7px 1048px #FFF , 180px 1353px #FFF , 1375px 872px #FFF , 230px 952px #FFF;
-          animation: animStar 100s linear infinite;
-      }
-      #stars2:after {
-          content: " ";
-          position: absolute;
-          top: 2000px;
-          width: 2px;
-          height: 2px;
-          background: transparent;
-          box-shadow: 1525px 16px #FFF , 800px 1234px #FFF , 772px 1261px #FFF , 1350px 1211px #FFF , 1179px 1382px #FFF , 1593px 1378px #FFF , 385px 1199px #FFF , 123px 1615px #FFF , 225px 1069px #FFF , 76px 1610px #FFF , 545px 465px #FFF , 1871px 1565px #FFF , 931px 1475px #FFF , 288px 484px #FFF , 1168px 1634px #FFF , 1132px 582px #FFF , 266px 551px #FFF , 958px 1243px #FFF , 604px 1196px #FFF , 1847px 1135px #FFF , 182px 1150px #FFF , 643px 207px #FFF , 195px 1950px #FFF , 901px 1346px #FFF , 1121px 378px #FFF , 1859px 845px #FFF , 718px 1223px #FFF , 1014px 638px #FFF , 1525px 534px #FFF , 903px 1689px #FFF , 798px 66px #FFF , 1499px 806px #FFF , 503px 467px #FFF , 996px 739px #FFF , 1234px 1701px #FFF , 613px 1915px #FFF , 1070px 969px #FFF , 959px 1300px #FFF , 480px 527px #FFF , 302px 1658px #FFF , 284px 1466px #FFF , 1265px 1031px #FFF , 1903px 683px #FFF , 601px 56px #FFF , 1133px 1681px #FFF , 849px 177px #FFF , 872px 102px #FFF , 1577px 1281px #FFF , 1356px 1958px #FFF , 1553px 1340px #FFF , 262px 987px #FFF , 787px 1684px #FFF , 154px 194px #FFF , 172px 1278px #FFF , 1384px 148px #FFF , 400px 582px #FFF , 1998px 1227px #FFF , 1730px 162px #FFF , 688px 31px #FFF , 983px 1472px #FFF , 1576px 324px #FFF , 183px 1006px #FFF , 158px 801px #FFF , 1955px 1115px #FFF , 1702px 1695px #FFF , 917px 1701px #FFF , 745px 1862px #FFF , 1129px 1315px #FFF , 890px 446px #FFF , 992px 1626px #FFF , 1017px 1228px #FFF , 188px 574px #FFF , 1649px 939px #FFF , 899px 568px #FFF , 353px 1003px #FFF , 1367px 1696px #FFF , 1532px 753px #FFF , 699px 1190px #FFF , 753px 1566px #FFF , 69px 159px #FFF , 19px 830px #FFF , 570px 351px #FFF , 364px 1947px #FFF , 1042px 198px #FFF , 668px 184px #FFF , 1551px 152px #FFF , 796px 1433px #FFF , 1043px 917px #FFF , 1449px 946px #FFF , 1617px 934px #FFF , 32px 657px #FFF , 491px 1236px #FFF , 658px 1052px #FFF , 715px 1937px #FFF , 452px 284px #FFF , 1521px 35px #FFF , 228px 733px #FFF , 1652px 372px #FFF , 1976px 633px #FFF , 1700px 1554px #FFF , 237px 1762px #FFF , 1929px 1487px #FFF , 1242px 1234px #FFF , 1794px 1405px #FFF , 456px 709px #FFF , 862px 1221px #FFF , 1674px 28px #FFF , 1255px 332px #FFF , 1841px 170px #FFF , 1075px 193px #FFF , 149px 962px #FFF , 741px 1520px #FFF , 1379px 544px #FFF , 1091px 1231px #FFF , 1364px 1157px #FFF , 1879px 720px #FFF , 462px 13px #FFF , 420px 305px #FFF , 574px 835px #FFF , 575px 426px #FFF , 1208px 816px #FFF , 743px 1122px #FFF , 1847px 230px #FFF , 450px 1644px #FFF , 1688px 1409px #FFF , 453px 1959px #FFF , 1661px 917px #FFF , 1236px 1313px #FFF , 98px 299px #FFF , 1372px 676px #FFF , 1209px 320px #FFF , 1523px 371px #FFF , 1947px 1930px #FFF , 36px 1499px #FFF , 66px 1418px #FFF , 581px 1642px #FFF , 1225px 1664px #FFF , 1764px 566px #FFF , 656px 1009px #FFF , 1155px 641px #FFF , 1275px 1534px #FFF , 1822px 1593px #FFF , 1798px 1283px #FFF , 994px 1852px #FFF , 1933px 31px #FFF , 1247px 1459px #FFF , 1148px 669px #FFF , 455px 262px #FFF , 1319px 1419px #FFF , 1637px 1307px #FFF , 147px 1499px #FFF , 1372px 1796px #FFF , 1973px 1616px #FFF , 1491px 251px #FFF , 72px 158px #FFF , 1519px 878px #FFF , 13px 955px #FFF , 1120px 1225px #FFF , 767px 1873px #FFF , 475px 1980px #FFF , 221px 1803px #FFF , 654px 623px #FFF , 982px 285px #FFF , 1856px 1165px #FFF , 1533px 944px #FFF , 937px 1457px #FFF , 1935px 664px #FFF , 1793px 292px #FFF , 858px 1983px #FFF , 390px 398px #FFF , 1313px 1297px #FFF , 725px 1096px #FFF , 1469px 1658px #FFF , 648px 1141px #FFF , 953px 255px #FFF , 286px 346px #FFF , 32px 1662px #FFF , 1272px 316px #FFF , 1252px 710px #FFF , 1337px 1505px #FFF , 565px 1464px #FFF , 1116px 506px #FFF , 1593px 163px #FFF , 214px 1048px #FFF , 1195px 1475px #FFF , 1384px 1765px #FFF , 706px 988px #FFF , 283px 1279px #FFF , 737px 1052px #FFF , 381px 1420px #FFF , 1630px 610px #FFF , 938px 693px #FFF , 1721px 1096px #FFF , 1210px 341px #FFF , 906px 1940px #FFF , 1007px 650px #FFF , 7px 1048px #FFF , 180px 1353px #FFF , 1375px 872px #FFF , 230px 952px #FFF;
-      }
+      <div class="status">
+        <span class="status-dot"></span>
+        Running
+      </div>
 
-      #stars3 {
-          width: 3px;
-          height: 3px;
-          background: transparent;
-          box-shadow: 1408px 274px #FFF , 895px 1719px #FFF , 958px 1846px #FFF , 1383px 219px #FFF , 453px 847px #FFF , 1092px 1479px #FFF , 1866px 1571px #FFF , 1279px 258px #FFF , 718px 1253px #FFF , 1905px 420px #FFF , 1720px 1477px #FFF , 340px 1013px #FFF , 1525px 1634px #FFF , 1873px 1892px #FFF , 1191px 1165px #FFF , 855px 949px #FFF , 1714px 394px #FFF , 1010px 1655px #FFF , 1172px 1204px #FFF , 1968px 1227px #FFF , 1260px 1735px #FFF , 1221px 816px #FFF , 535px 1270px #FFF , 314px 1383px #FFF , 701px 1365px #FFF , 398px 119px #FFF , 1577px 1449px #FFF , 266px 943px #FFF , 1041px 433px #FFF , 520px 69px #FFF , 494px 958px #FFF , 1702px 9px #FFF , 906px 1403px #FFF , 149px 1620px #FFF , 353px 1383px #FFF , 1150px 143px #FFF , 980px 810px #FFF , 848px 450px #FFF , 1929px 348px #FFF , 1679px 1631px #FFF , 1717px 361px #FFF , 557px 1029px #FFF , 397px 58px #FFF , 1059px 1824px #FFF , 1322px 1394px #FFF , 71px 1738px #FFF , 237px 1273px #FFF , 1961px 1497px #FFF , 1502px 637px #FFF , 564px 1253px #FFF , 1281px 204px #FFF , 314px 1260px #FFF , 1148px 1699px #FFF , 1172px 643px #FFF , 1392px 969px #FFF , 827px 963px #FFF , 1416px 1868px #FFF , 62px 1369px #FFF , 1640px 565px #FFF , 1829px 685px #FFF , 1798px 9px #FFF , 1064px 1963px #FFF , 165px 1315px #FFF , 1251px 173px #FFF , 47px 168px #FFF , 945px 353px #FFF , 281px 1641px #FFF , 348px 40px #FFF , 276px 256px #FFF , 1967px 1945px #FFF , 268px 669px #FFF , 1208px 798px #FFF , 1554px 1138px #FFF , 1486px 263px #FFF , 1248px 1369px #FFF , 884px 430px #FFF , 1098px 1795px #FFF , 439px 1180px #FFF , 43px 1602px #FFF , 1515px 1661px #FFF , 800px 1695px #FFF , 353px 21px #FFF , 1794px 38px #FFF , 493px 928px #FFF , 242px 1324px #FFF , 466px 684px #FFF , 1933px 1896px #FFF , 218px 1123px #FFF , 577px 935px #FFF , 576px 72px #FFF , 669px 235px #FFF , 1607px 366px #FFF , 460px 1601px #FFF , 121px 867px #FFF , 876px 7px #FFF , 1208px 1621px #FFF , 295px 362px #FFF , 1683px 108px #FFF , 1247px 849px #FFF , 1468px 732px #FFF;
-          animation: animStar 150s linear infinite;
-      }
-      #stars3:after {
-          content: " ";
-          position: absolute;
-          top: 2000px;
-          width: 3px;
-          height: 3px;
-          background: transparent;
-          box-shadow: 1408px 274px #FFF , 895px 1719px #FFF , 958px 1846px #FFF , 1383px 219px #FFF , 453px 847px #FFF , 1092px 1479px #FFF , 1866px 1571px #FFF , 1279px 258px #FFF , 718px 1253px #FFF , 1905px 420px #FFF , 1720px 1477px #FFF , 340px 1013px #FFF , 1525px 1634px #FFF , 1873px 1892px #FFF , 1191px 1165px #FFF , 855px 949px #FFF , 1714px 394px #FFF , 1010px 1655px #FFF , 1172px 1204px #FFF , 1968px 1227px #FFF , 1260px 1735px #FFF , 1221px 816px #FFF , 535px 1270px #FFF , 314px 1383px #FFF , 701px 1365px #FFF , 398px 119px #FFF , 1577px 1449px #FFF , 266px 943px #FFF , 1041px 433px #FFF , 520px 69px #FFF , 494px 958px #FFF , 1702px 9px #FFF , 906px 1403px #FFF , 149px 1620px #FFF , 353px 1383px #FFF , 1150px 143px #FFF , 980px 810px #FFF , 848px 450px #FFF , 1929px 348px #FFF , 1679px 1631px #FFF , 1717px 361px #FFF , 557px 1029px #FFF , 397px 58px #FFF , 1059px 1824px #FFF , 1322px 1394px #FFF , 71px 1738px #FFF , 237px 1273px #FFF , 1961px 1497px #FFF , 1502px 637px #FFF , 564px 1253px #FFF , 1281px 204px #FFF , 314px 1260px #FFF , 1148px 1699px #FFF , 1172px 643px #FFF , 1392px 969px #FFF , 827px 963px #FFF , 1416px 1868px #FFF , 62px 1369px #FFF , 1640px 565px #FFF , 1829px 685px #FFF , 1798px 9px #FFF , 1064px 1963px #FFF , 165px 1315px #FFF , 1251px 173px #FFF , 47px 168px #FFF , 945px 353px #FFF , 281px 1641px #FFF , 348px 40px #FFF , 276px 256px #FFF , 1967px 1945px #FFF , 268px 669px #FFF , 1208px 798px #FFF , 1554px 1138px #FFF , 1486px 263px #FFF , 1248px 1369px #FFF , 884px 430px #FFF , 1098px 1795px #FFF , 439px 1180px #FFF , 43px 1602px #FFF , 1515px 1661px #FFF , 800px 1695px #FFF , 353px 21px #FFF , 1794px 38px #FFF , 493px 928px #FFF , 242px 1324px #FFF , 466px 684px #FFF , 1933px 1896px #FFF , 218px 1123px #FFF , 577px 935px #FFF , 576px 72px #FFF , 669px 235px #FFF , 1607px 366px #FFF , 460px 1601px #FFF , 121px 867px #FFF , 876px 7px #FFF , 1208px 1621px #FFF , 295px 362px #FFF , 1683px 108px #FFF , 1247px 849px #FFF , 1468px 732px #FFF;
-      }
+      <p class="message">
+        Your application is ready. Edit your controller to start building.<br>
+        <code>{{message}}</code>
+      </p>
 
-      #title {
-          position: absolute;
-          top: 50%;
-          left: 0;
-          right: 0;
-          color: #FFF;
-          text-align: center;
-          font-family: "lato", sans-serif;
-          font-weight: 300;
-          font-size: 20px;
-          letter-spacing: 10px;
-          margin-top: -60px;
-          padding-left: 10px;
-      }
-
-      #logo {
-          width: 400px;
-          margin-bottom: 10px;
-      }
-
-      @keyframes animStar {
-          from {
-              transform: translate3d(0, 0px, 0);
-          }
-          to {
-              transform: translateY(0, -2000px, 0);
-          }
-      }
-    </style>
-  </head>
-  <body>
-    <link href='https://fonts.googleapis.com/css?family=Lato:300,400,700' rel='stylesheet' type='text/css'>
-    <div id='stars'></div>
-    <div id='stars2'></div>
-    <div id='stars3'></div>
-    <div id='title'>
-      <span>
-        <svg id="logo" id="Layer_1" data-name="Layer 1" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 2500 784.5"><defs><style>.cls-1{fill:#f5f6fa;}.cls-2{fill:#8447ff;}</style></defs><path class="cls-1" d="M1132.5,768c-4.3.2-8.7.3-13.1.3-162.5,0-294.2-131.7-294.2-294.2a293.38,293.38,0,0,1,9.3-73.6l61-61.4,5.7,47.6a268.11,268.11,0,0,0-24.9,113C876.3,643.9,989.9,761.5,1132.5,768Z"/><path class="cls-1" d="M1413.6,474.1c0,4.4-.1,8.8-.3,13.1-6.5-142.5-124.2-256.1-268.3-256.1a267,267,0,0,0-129.5,33.2L967.6,262l57.9-66.8a294.75,294.75,0,0,1,93.9-15.3C1281.8,179.9,1413.6,311.6,1413.6,474.1Z"/><polygon class="cls-2" points="649.6 572 903.1 316.9 922.8 480.7 931.3 318.5 1207.1 555.3 949.6 297.8 1106.7 278.9 946 271.3 1181.1 0 927.7 252.4 908.2 90.4 900.6 253.5 628.5 18.7 884 274.2 719.8 293.1 882.3 300.8 649.6 572"/><path class="cls-1" d="M70.6,768.3V739.6H103q25.95,0,41.3-19.3t15.3-52.5V182.2C159,166,150.9,158,135.4,158H70.6V129.2H245.4L551.8,621.6V228.4q0-32.55-15.3-51.6c-10.2-12.6-23.6-19-40.4-19H463.8V129.2H677.4v28.7H645.1c-16.8,0-30.5,6.4-41.3,19.3s-16.2,30.4-16.2,52.5V784.4H551.7L199,227.1h-3.6V667.8c0,22.1,5.2,39.7,15.7,52.5s24.1,19.3,40.8,19.3h32.3v28.7Z"/><path class="cls-1" d="M1637.9,784.5,1429.6,197.2c-5.4-14.8-12.3-25.1-20.6-30.7s-19.2-8.5-32.3-8.5h-56.5V129.2h285.5v28.7h-59.2c-8.4,0-15.6,2.3-21.5,6.8s-8.9,9.8-8.9,15.8a60.49,60.49,0,0,0,3.5,19.9l154.2,432.8,119.6-365.5c7-22.2,10.6-43.2,10.6-63,0-12.6-3.7-23.5-11.1-32.8s-18.9-14-34.4-14H1710V129.2h241.4v28.7H1918q-53.85,0-75.4,65.5l-182.2,561h-22.5Z"/><path class="cls-1" d="M1806.3,768.3V739.6h33.2q52.05,0,75.4-65.5l194.7-544.9H2132l194.8,570.9c10.8,26.3,28.7,39.5,53.9,39.5H2431v28.7H2152.6V739.6h59.2c9,0,16.5-2.2,22.4-6.7s9-9.7,9-15.7c0-7.8-1.2-14.3-3.6-19.7l-39.5-117.6H1998.8l-21.5,60.5q-14,35.1-13.9,52.7a51.49,51.49,0,0,0,11,32.5c7.3,9.4,19.4,14.1,36.1,14.1h47.6v28.7H1806.3Zm204.5-220.8h177.4L2098,284.9Z"/></svg><br />
-        Congratulations! Nova is running.<br />
-        <span>
-          <pre>> {{message}} <</pre>
-        </span>
-      </span>
+      <div class="links">
+        <a href="https://novaframework.org/docs" class="primary">Documentation</a>
+        <a href="https://github.com/novaframework" class="secondary">GitHub</a>
+      </div>
     </div>
-  </body>
+
+    <p class="footer">
+      Built with <a href="https://novaframework.org">Nova Framework</a> for Erlang/OTP
+    </p>
+  </div>
+</body>
 </html>


### PR DESCRIPTION
## Summary
- Replace dated 2014-era CSS stars landing page with clean, modern card-based design
- Fix broken CSS animation (`translateY` had wrong arguments), duplicate `id` on SVG, `<link>` in `<body>`, missing DOCTYPE and viewport meta
- Add automatic light/dark mode via `prefers-color-scheme`, responsive layout, system font stack
- Reduce template size from ~25KB to ~6KB with zero external dependencies (no more Google Fonts CDN)

## Test plan
- [ ] `rebar3 new nova testapp` and verify landing page renders at `localhost:8080`
- [ ] Verify light and dark mode switching
- [ ] Verify responsive layout on mobile viewport
- [ ] Verify `{{message}}` template variable renders correctly