### PR TITLE
feat: add rebar3 nova new command with composable flags

### DIFF
--- a/src/rebar3_nova.erl
+++ b/src/rebar3_nova.erl
@@ -25,7 +25,8 @@ init(State) ->
                     rebar3_nova_middleware,
                     rebar3_nova_config,
                     rebar3_nova_audit,
-                    rebar3_nova_release
+                    rebar3_nova_release,
+                    rebar3_nova_new
                 ]
             );
         ["git"] ->
@@ -47,7 +48,8 @@ init(State) ->
                     rebar3_nova_middleware,
                     rebar3_nova_config,
                     rebar3_nova_audit,
-                    rebar3_nova_release
+                    rebar3_nova_release,
+                    rebar3_nova_new
                 ]
             );
         SomethingElse ->

--- a/src/rebar3_nova_new.erl
+++ b/src/rebar3_nova_new.erl
@@ -1,0 +1,1138 @@
+-module(rebar3_nova_new).
+
+-export([init/1, do/1, format_error/1]).
+-export([generate_project/2, validate_flags/1]).
+
+-define(PROVIDER, new).
+-define(DEPS, []).
+
+-spec init(rebar_state:t()) -> {ok, rebar_state:t()}.
+init(State) ->
+    Provider = providers:create([
+        {name, ?PROVIDER},
+        {module, ?MODULE},
+        {namespace, nova},
+        {bare, true},
+        {deps, ?DEPS},
+        {example,
+            "rebar3 nova new myapp [--kura] [--pgo] [--arizona] [--lfe] [--ci] [--docker] [--otel]"},
+        {opts, [
+            {name, $n, "name", string, "Project name"},
+            {kura, undefined, "kura", boolean, "Include Kura database layer"},
+            {pgo, undefined, "pgo", boolean, "Include PGO PostgreSQL client"},
+            {arizona, undefined, "arizona", boolean, "Include Arizona live views"},
+            {lfe, undefined, "lfe", boolean, "Generate LFE source files"},
+            {ci, undefined, "ci", boolean, "Generate GitHub Actions CI workflow"},
+            {docker, undefined, "docker", boolean, "Generate Dockerfile"},
+            {otel, undefined, "otel", boolean, "Include OpenTelemetry instrumentation"}
+        ]},
+        {short_desc, "Create a new Nova project"},
+        {desc, "Create a new Nova project with composable flags"}
+    ]),
+    {ok, rebar_state:add_provider(State, Provider)}.
+
+-spec do(rebar_state:t()) -> {ok, rebar_state:t()} | {error, string()}.
+do(State) ->
+    {Opts, Args} = rebar_state:command_parsed_args(State),
+    Name = resolve_name(Opts, Args),
+    Flags = parse_flags(Opts),
+    case validate_flags(Flags) of
+        ok ->
+            generate_project(Name, Flags),
+            print_summary(Name, Flags),
+            {ok, State};
+        {error, Reason} ->
+            {error, Reason}
+    end.
+
+-spec format_error(any()) -> iolist().
+format_error(Reason) ->
+    io_lib:format("~p", [Reason]).
+
+%%======================================================================
+%% Flag parsing
+%%======================================================================
+
+resolve_name(Opts, Args) ->
+    case proplists:get_value(name, Opts) of
+        undefined ->
+            case Args of
+                [N | _] -> N;
+                _ -> error(missing_project_name)
+            end;
+        N ->
+            N
+    end.
+
+parse_flags(Opts) ->
+    #{
+        kura => proplists:get_value(kura, Opts, false),
+        pgo => proplists:get_value(pgo, Opts, false),
+        arizona => proplists:get_value(arizona, Opts, false),
+        lfe => proplists:get_value(lfe, Opts, false),
+        ci => proplists:get_value(ci, Opts, false),
+        docker => proplists:get_value(docker, Opts, false),
+        otel => proplists:get_value(otel, Opts, false)
+    }.
+
+validate_flags(#{kura := true, pgo := true}) ->
+    {error, "--kura and --pgo are mutually exclusive (kura uses pgo internally)"};
+validate_flags(_) ->
+    ok.
+
+%%======================================================================
+%% Project generation
+%%======================================================================
+
+generate_project(Name, Flags) ->
+    case filelib:is_dir(Name) of
+        true ->
+            error({dir_exists, Name});
+        false ->
+            ok
+    end,
+    generate_rebar_config(Name, Flags),
+    generate_app_src(Name, Flags),
+    generate_app(Name, Flags),
+    generate_sup(Name, Flags),
+    generate_router(Name, Flags),
+    generate_controller(Name, Flags),
+    generate_dev_sys_config(Name, Flags),
+    generate_prod_sys_config(Name, Flags),
+    generate_vm_args(Name),
+    generate_tool_versions(Name),
+    generate_gitignore(Name),
+    copy_favicon(Name),
+    maybe_generate_view(Name, Flags),
+    maybe_generate_kura(Name, Flags),
+    maybe_generate_pgo(Name, Flags),
+    maybe_generate_arizona(Name, Flags),
+    maybe_generate_ci(Name, Flags),
+    maybe_generate_docker(Name, Flags).
+
+%%======================================================================
+%% rebar.config
+%%======================================================================
+
+generate_rebar_config(Name, Flags) ->
+    Path = filename:join(Name, "rebar.config"),
+    Content = [
+        "%% -*- mode: erlang;erlang-indent-level: 4;indent-tabs-mode: nil -*-\n\n",
+        "{erl_opts, [debug_info]}.\n",
+        "{src_dirs, [{\"src\", [{recursive, true}]}]}.\n",
+        "{shell, [{config, \"./config/dev_sys.config.src\"}]}.\n\n",
+        rebar_erlydtl_opts(Flags),
+        rebar_deps(Flags),
+        rebar_relx(Name, Flags),
+        rebar_profiles(Flags),
+        "{dialyzer, [{plt_apps, all_deps}]}.\n\n",
+        rebar_plugins(Flags),
+        rebar_erlfmt(Flags),
+        rebar_provider_hooks(Flags),
+        rebar_xref()
+    ],
+    rebar3_nova_utils:write_file(Path, Content).
+
+rebar_erlydtl_opts(#{arizona := true}) ->
+    [];
+rebar_erlydtl_opts(#{lfe := true}) ->
+    [
+        "{erlydtl_opts, [\n",
+        "    {doc_root, \"src/views\"},\n",
+        "    {recursive, true},\n",
+        "    {libraries, [\n",
+        "        {nova_erlydtl_inventory, nova_erlydtl_inventory}\n",
+        "    ]},\n",
+        "    {default_libraries, [nova_erlydtl_inventory]}\n",
+        "]}.\n\n"
+    ];
+rebar_erlydtl_opts(_) ->
+    [
+        "{erlydtl_opts, [\n",
+        "    {doc_root, \"src/views\"},\n",
+        "    {recursive, true},\n",
+        "    {libraries, [\n",
+        "        {nova_erlydtl_inventory, nova_erlydtl_inventory}\n",
+        "    ]},\n",
+        "    {default_libraries, [nova_erlydtl_inventory]}\n",
+        "]}.\n\n"
+    ].
+
+rebar_deps(Flags) ->
+    BaseDeps =
+        case maps:get(lfe, Flags) of
+            true -> ["    nova,\n", "    {logjam, \"1.2.4\"}"];
+            false -> ["    nova,\n", "    {flatlog, \"0.1.2\"}"]
+        end,
+    KuraDep =
+        case maps:get(kura, Flags) of
+            true -> [",\n    kura"];
+            false -> []
+        end,
+    PgoDep =
+        case maps:get(pgo, Flags) of
+            true -> [",\n    pgo"];
+            false -> []
+        end,
+    ArizonaDeps =
+        case maps:get(arizona, Flags) of
+            true -> [",\n    arizona_core,\n    arizona_nova"];
+            false -> []
+        end,
+    LfeDep =
+        case maps:get(lfe, Flags) of
+            true ->
+                [",\n    {lfe, {git, \"http://github.com/rvirding/lfe\", {branch, \"develop\"}}}"];
+            false ->
+                []
+        end,
+    OtelDeps =
+        case maps:get(otel, Flags) of
+            true ->
+                [
+                    ",\n    opentelemetry,\n    opentelemetry_api,\n    opentelemetry_exporter,\n    opentelemetry_nova"
+                ];
+            false ->
+                []
+        end,
+    ["{deps, [\n", BaseDeps, KuraDep, PgoDep, ArizonaDeps, LfeDep, OtelDeps, "\n]}.\n\n"].
+
+rebar_relx(Name, _Flags) ->
+    [
+        "{relx, [\n",
+        "    {release, {",
+        Name,
+        ", git}, [\n",
+        "        ",
+        Name,
+        ",\n",
+        "        sasl\n",
+        "    ]},\n",
+        "    {mode, dev},\n",
+        "    {sys_config_src, \"./config/dev_sys.config.src\"},\n",
+        "    {vm_args_src, \"./config/vm.args.src\"}\n",
+        "]}.\n\n"
+    ].
+
+rebar_profiles(_Flags) ->
+    [
+        "{profiles, [\n",
+        "    {prod, [\n",
+        "        {relx, [\n",
+        "            {mode, prod},\n",
+        "            {sys_config_src, \"./config/prod_sys.config.src\"}\n",
+        "        ]}\n",
+        "    ]},\n",
+        "    {test, [\n",
+        "        {erl_opts, [nowarn_export_all, warnings_as_errors, {i, \"test/util\"}]},\n",
+        "        {deps, [\n",
+        "            {meck, \"1.1.0\"}\n",
+        "        ]},\n",
+        "        {ct_opts, [{sys_config, \"./config/dev_sys.config.src\"}]},\n",
+        "        {extra_src_dirs, [{\"test\", [{recursive, true}]}]},\n",
+        "        {xref_extra_paths, [\"test\"]}\n",
+        "    ]}\n",
+        "]}.\n\n"
+    ].
+
+rebar_plugins(Flags) ->
+    ErlydtlPlugin =
+        case maps:get(arizona, Flags) of
+            true ->
+                [];
+            false ->
+                [
+                    "    {rebar3_erlydtl_plugin, \".*\",\n",
+                    "        {git, \"https://github.com/erlydtl/rebar3_erlydtl_plugin.git\", {branch, \"master\"}}},\n"
+                ]
+        end,
+    LfePlugin =
+        case maps:get(lfe, Flags) of
+            true ->
+                [
+                    "    {rebar3_lfe, {git, \"http://github.com/lfe-rebar3/rebar3_lfe\", {branch, \"release/0.4.x\"}}},\n"
+                ];
+            false ->
+                []
+        end,
+    [
+        "{project_plugins, [\n",
+        ErlydtlPlugin,
+        LfePlugin,
+        "    {rebar3_nova, \".*\",\n",
+        "        {git, \"https://github.com/novaframework/rebar3_nova.git\", {branch, \"master\"}}},\n",
+        "    {erlfmt, \"~>1.7\"}\n",
+        "]}.\n\n"
+    ].
+
+rebar_erlfmt(_Flags) ->
+    [
+        "{erlfmt, [\n",
+        "    write,\n",
+        "    {files, [\n",
+        "        \"rebar.config\",\n",
+        "        \"src/*.app.src\",\n",
+        "        \"src/**/{*.erl, *.hrl}\",\n",
+        "        \"test/**/{*.erl, *.hrl}\"\n",
+        "    ]},\n",
+        "    {exclude_files, [\"config/vm.args.src\", \"config/prod_sys.config.src\"]}\n",
+        "]}.\n\n"
+    ].
+
+rebar_provider_hooks(#{lfe := true}) ->
+    [
+        "{provider_hooks, [\n",
+        "    {pre, [{compile, {erlydtl, compile}},\n",
+        "           {compile, {lfe, compile}}]}\n",
+        "]}.\n\n"
+    ];
+rebar_provider_hooks(#{arizona := true}) ->
+    [];
+rebar_provider_hooks(_) ->
+    [].
+
+rebar_xref() ->
+    [
+        "{xref_checks, [\n",
+        "    undefined_function_calls,\n",
+        "    undefined_functions,\n",
+        "    locals_not_used,\n",
+        "    deprecated_function_calls,\n",
+        "    deprecated_functions\n",
+        "]}.\n"
+    ].
+
+%%======================================================================
+%% app.src
+%%======================================================================
+
+generate_app_src(Name, Flags) ->
+    Path = filename:join([Name, "src", Name ++ ".app.src"]),
+    Apps = app_src_applications(Flags),
+    Content = [
+        "%% -*- mode: erlang;erlang-indent-level: 4;indent-tabs-mode: nil -*-\n",
+        "{application, ",
+        Name,
+        ", [\n",
+        "    {description, \"",
+        Name,
+        " managed by Nova\"},\n",
+        "    {vsn, git},\n",
+        "    {registered, []},\n",
+        "    {mod, {",
+        Name,
+        "_app, []}},\n",
+        "    {included_applications, []},\n",
+        "    {applications, [\n",
+        "        ",
+        Apps,
+        "\n",
+        "    ]},\n",
+        "    {env, []},\n",
+        "    {modules, []},\n",
+        "    {maintainers, []},\n",
+        "    {licenses, [\"Apache 2.0\"]},\n",
+        "    {links, []}\n",
+        "]}.\n"
+    ],
+    rebar3_nova_utils:write_file(Path, Content).
+
+app_src_applications(Flags) ->
+    Base = ["kernel,\n        stdlib,\n        nova"],
+    Kura =
+        case maps:get(kura, Flags) of
+            true -> [",\n        kura"];
+            false -> []
+        end,
+    Pgo =
+        case maps:get(pgo, Flags) of
+            true -> [",\n        pgo"];
+            false -> []
+        end,
+    Arizona =
+        case maps:get(arizona, Flags) of
+            true -> [",\n        arizona_core,\n        arizona_nova"];
+            false -> []
+        end,
+    Otel =
+        case maps:get(otel, Flags) of
+            true -> [",\n        opentelemetry,\n        opentelemetry_api"];
+            false -> []
+        end,
+    [Base, Kura, Pgo, Arizona, Otel].
+
+%%======================================================================
+%% app.erl / app.lfe
+%%======================================================================
+
+generate_app(Name, #{lfe := true}) ->
+    Path = filename:join([Name, "src", Name ++ "_app.lfe"]),
+    Content = [
+        "(defmodule ",
+        Name,
+        "_app\n",
+        "  (behaviour gen_server)\n",
+        "  (export\n",
+        "    ;; app implementation\n",
+        "    (start 2)\n",
+        "    (stop 0)))\n\n",
+        "(include-lib \"logjam/include/logjam.hrl\")\n\n",
+        "(defun start (_type _args)\n",
+        "  (log-info \"Starting ",
+        Name,
+        " application ...\")\n",
+        "  (",
+        Name,
+        ".sup:start_link))\n\n",
+        "(defun stop ()\n",
+        "  (",
+        Name,
+        ".sup:stop)\n",
+        "  'ok)\n"
+    ],
+    rebar3_nova_utils:write_file(Path, Content);
+generate_app(Name, #{otel := true}) ->
+    Path = filename:join([Name, "src", Name ++ "_app.erl"]),
+    Content = [
+        "-module(",
+        Name,
+        "_app).\n\n",
+        "-behaviour(application).\n\n",
+        "-export([start/2, stop/1]).\n\n",
+        "start(_StartType, _StartArgs) ->\n",
+        "    opentelemetry:setup(),\n",
+        "    ",
+        Name,
+        "_sup:start_link().\n\n",
+        "stop(_State) ->\n",
+        "    ok.\n"
+    ],
+    rebar3_nova_utils:write_file(Path, Content);
+generate_app(Name, _Flags) ->
+    Path = filename:join([Name, "src", Name ++ "_app.erl"]),
+    Content = [
+        "-module(",
+        Name,
+        "_app).\n\n",
+        "-behaviour(application).\n\n",
+        "-export([start/2, stop/1]).\n\n",
+        "start(_StartType, _StartArgs) ->\n",
+        "    ",
+        Name,
+        "_sup:start_link().\n\n",
+        "stop(_State) ->\n",
+        "    ok.\n"
+    ],
+    rebar3_nova_utils:write_file(Path, Content).
+
+%%======================================================================
+%% sup.erl / sup.lfe
+%%======================================================================
+
+generate_sup(Name, #{lfe := true}) ->
+    Path = filename:join([Name, "src", Name ++ ".sup.lfe"]),
+    Content = [
+        "(defmodule ",
+        Name,
+        ".sup\n",
+        "  (behaviour supervisor)\n",
+        "  (export\n",
+        "   (start_link 0)\n",
+        "   (stop 0)\n",
+        "   (init 1)))\n\n",
+        "(defun SERVER () (MODULE))\n",
+        "(defun supervisor-opts () '())\n",
+        "(defun sup-flags ()\n",
+        "  `#M(strategy one_for_all\n",
+        "      intensity 0\n",
+        "      period 1))\n\n",
+        "(defun start_link ()\n",
+        "  (supervisor:start_link `#(local ,(SERVER))\n",
+        "                         (MODULE)\n",
+        "                         (supervisor-opts)))\n\n",
+        "(defun stop ()\n",
+        "  (gen_server:call (SERVER) 'stop))\n\n",
+        "(defun init (_args)\n",
+        "  `#(ok #(,(sup-flags) ())))\n"
+    ],
+    rebar3_nova_utils:write_file(Path, Content);
+generate_sup(Name, #{kura := true}) ->
+    Path = filename:join([Name, "src", Name ++ "_sup.erl"]),
+    Content = [
+        "-module(",
+        Name,
+        "_sup).\n\n",
+        "-behaviour(supervisor).\n\n",
+        "-export([start_link/0]).\n",
+        "-export([init/1]).\n\n",
+        "-define(SERVER, ?MODULE).\n\n",
+        "start_link() ->\n",
+        "    supervisor:start_link({local, ?SERVER}, ?MODULE, []).\n\n",
+        "init([]) ->\n",
+        "    SupFlags = #{strategy => one_for_all},\n",
+        "    ChildSpecs = [\n",
+        "        #{id => ",
+        Name,
+        "_repo,\n",
+        "          start => {",
+        Name,
+        "_repo, start_link, []},\n",
+        "          type => worker}\n",
+        "    ],\n",
+        "    {ok, {SupFlags, ChildSpecs}}.\n"
+    ],
+    rebar3_nova_utils:write_file(Path, Content);
+generate_sup(Name, _Flags) ->
+    Path = filename:join([Name, "src", Name ++ "_sup.erl"]),
+    Content = [
+        "-module(",
+        Name,
+        "_sup).\n\n",
+        "-behaviour(supervisor).\n\n",
+        "-export([start_link/0]).\n",
+        "-export([init/1]).\n\n",
+        "-define(SERVER, ?MODULE).\n\n",
+        "start_link() ->\n",
+        "    supervisor:start_link({local, ?SERVER}, ?MODULE, []).\n\n",
+        "init([]) ->\n",
+        "    SupFlags = #{strategy => one_for_all},\n",
+        "    ChildSpecs = [],\n",
+        "    {ok, {SupFlags, ChildSpecs}}.\n"
+    ],
+    rebar3_nova_utils:write_file(Path, Content).
+
+%%======================================================================
+%% router
+%%======================================================================
+
+generate_router(Name, #{lfe := true, arizona := true}) ->
+    Path = filename:join([Name, "src", Name ++ "_router.lfe"]),
+    Content = [
+        "(defmodule ",
+        Name,
+        "_router\n",
+        "  (export\n",
+        "   (routes 1)))\n\n",
+        "(defun routes\n",
+        "  (_)\n",
+        "   `(#M(prefix \"\"\n",
+        "         security false\n",
+        "         routes\n",
+        "           (\n",
+        "            #(\"/heartbeat\" ,(lambda (_) #(status 200)) #M(methods (get)))\n",
+        "            #(\"/\" ,(lambda (params) (",
+        Name,
+        "_main_controller:index params))\n",
+        "              #M(methods (get)))\n",
+        "            ))\n",
+        "      #M(prefix \"\"\n",
+        "         security false\n",
+        "         routes\n",
+        "           (\n",
+        "            #(\"/ws\" ,(lambda (params) (arizona_nova_adapter:handler params))\n",
+        "              #M(protocol ws))\n",
+        "            ))))\n"
+    ],
+    rebar3_nova_utils:write_file(Path, Content);
+generate_router(Name, #{lfe := true}) ->
+    Path = filename:join([Name, "src", Name ++ "_router.lfe"]),
+    Content = [
+        "(defmodule ",
+        Name,
+        "_router\n",
+        "  (export\n",
+        "   (routes 1)))\n\n",
+        "(defun routes\n",
+        "  (_)\n",
+        "   `(#M(prefix \"\"\n",
+        "         security false\n",
+        "         routes\n",
+        "           (\n",
+        "            #(\"/heartbeat\" ,(lambda (_) #(status 200)) #M(methods (get)))\n",
+        "            #(\"/\" ,(lambda (params) (",
+        Name,
+        "_main_controller:index params))\n",
+        "              #M(methods (get)))\n",
+        "            ))))\n"
+    ],
+    rebar3_nova_utils:write_file(Path, Content);
+generate_router(Name, #{arizona := true}) ->
+    Path = filename:join([Name, "src", Name ++ "_router.erl"]),
+    Content = [
+        "-module(",
+        Name,
+        "_router).\n",
+        "-behaviour(nova_router).\n\n",
+        "-export([routes/1]).\n\n",
+        "routes(_Environment) ->\n",
+        "    [\n",
+        "        #{\n",
+        "            prefix => \"\",\n",
+        "            security => false,\n",
+        "            routes => [\n",
+        "                {\"/\", fun ",
+        Name,
+        "_main_controller:index/1, #{methods => [get]}},\n",
+        "                {\"/heartbeat\", fun(_) -> {status, 200} end, #{methods => [get]}}\n",
+        "            ]\n",
+        "        },\n",
+        "        #{\n",
+        "            prefix => \"\",\n",
+        "            security => false,\n",
+        "            routes => [\n",
+        "                {\"/ws\", fun arizona_nova_adapter:handler/1, #{protocol => ws}}\n",
+        "            ]\n",
+        "        }\n",
+        "    ].\n"
+    ],
+    rebar3_nova_utils:write_file(Path, Content);
+generate_router(Name, _Flags) ->
+    Path = filename:join([Name, "src", Name ++ "_router.erl"]),
+    Content = [
+        "-module(",
+        Name,
+        "_router).\n",
+        "-behaviour(nova_router).\n\n",
+        "-export([routes/1]).\n\n",
+        "routes(_Environment) ->\n",
+        "    [\n",
+        "        #{\n",
+        "            prefix => \"\",\n",
+        "            security => false,\n",
+        "            routes => [\n",
+        "                {\"/\", fun ",
+        Name,
+        "_main_controller:index/1, #{methods => [get]}},\n",
+        "                {\"/heartbeat\", fun(_) -> {status, 200} end, #{methods => [get]}}\n",
+        "            ]\n",
+        "        }\n",
+        "    ].\n"
+    ],
+    rebar3_nova_utils:write_file(Path, Content).
+
+%%======================================================================
+%% controller
+%%======================================================================
+
+generate_controller(Name, #{lfe := true}) ->
+    Path = filename:join([Name, "src", "controllers", Name ++ "_main_controller.lfe"]),
+    Content = [
+        "(defmodule ",
+        Name,
+        "_main_controller\n",
+        "  (export\n",
+        "   (index 1)))\n\n",
+        "(defun index\n",
+        "  (_)\n",
+        "    `#(status 200 #M() \"nova is running!\"))\n"
+    ],
+    rebar3_nova_utils:write_file(Path, Content);
+generate_controller(Name, _Flags) ->
+    Path = filename:join([Name, "src", "controllers", Name ++ "_main_controller.erl"]),
+    Content = [
+        "-module(",
+        Name,
+        "_main_controller).\n\n",
+        "-export([index/1]).\n\n",
+        "index(_Req) ->\n",
+        "    {ok, [{message, \"Hello world!\"}]}.\n"
+    ],
+    rebar3_nova_utils:write_file(Path, Content).
+
+%%======================================================================
+%% dev_sys.config.src
+%%======================================================================
+
+generate_dev_sys_config(Name, Flags) ->
+    Path = filename:join([Name, "config", "dev_sys.config.src"]),
+    Content = [
+        "%% -*- mode: erlang;erlang-indent-level: 4;indent-tabs-mode: nil -*-\n\n",
+        "[\n",
+        sys_config_kernel(dev, Flags),
+        sys_config_nova(Name, dev, Flags),
+        sys_config_pgo(Name, dev, Flags),
+        sys_config_arizona(Name, dev, Flags),
+        sys_config_otel(dev, Flags),
+        "].\n"
+    ],
+    rebar3_nova_utils:write_file(Path, Content).
+
+%%======================================================================
+%% prod_sys.config.src
+%%======================================================================
+
+generate_prod_sys_config(Name, Flags) ->
+    Path = filename:join([Name, "config", "prod_sys.config.src"]),
+    Content = [
+        "%% -*- mode: erlang;erlang-indent-level: 4;indent-tabs-mode: nil -*-\n\n",
+        "[\n",
+        sys_config_kernel(prod, Flags),
+        sys_config_nova(Name, prod, Flags),
+        sys_config_pgo(Name, prod, Flags),
+        sys_config_arizona(Name, prod, Flags),
+        sys_config_otel(prod, Flags),
+        "].\n"
+    ],
+    rebar3_nova_utils:write_file(Path, Content).
+
+%%----------------------------------------------------------------------
+%% sys.config section builders
+%%----------------------------------------------------------------------
+
+sys_config_kernel(dev, #{lfe := true}) ->
+    [
+        " {kernel, [\n",
+        "     {logger, [\n",
+        "         {handler, default, logger_std_h,\n",
+        "          #{level => info,\n",
+        "            formatter => {logjam,\n",
+        "              #{colored => true,\n",
+        "                time_designator => $\\s,\n",
+        "                time_offset => \"\",\n",
+        "                time_unit => second,\n",
+        "                strip_tz => true,\n",
+        "                level_capitalize => true\n",
+        "              }\n",
+        "            }\n",
+        "           }\n",
+        "          }\n",
+        "     ]}\n",
+        " ]},\n"
+    ];
+sys_config_kernel(dev, _Flags) ->
+    [
+        " {kernel, [\n",
+        "     {logger_level, debug},\n",
+        "     #{formatter => {flatlog, #{\n",
+        "         map_depth => 3,\n",
+        "         term_depth => 50,\n",
+        "         colored => true,\n",
+        "         template => [colored_start, \"[\\033[1m\", level, \"\\033[0m\", colored_start,\"] [\", time, \"]\",\n",
+        "                      colored_end, \" \", msg, \" (\", mfa, \")\\n\"]\n",
+        "     }}}\n",
+        " ]},\n"
+    ];
+sys_config_kernel(prod, _Flags) ->
+    [
+        " {kernel, [\n",
+        "     {logger_level, info},\n",
+        "     {logger,\n",
+        "      [{handler, default, logger_std_h,\n",
+        "        #{level => error,\n",
+        "          config => #{file => \"log/erlang.log\"}}}\n",
+        "      ]}\n",
+        " ]},\n"
+    ].
+
+sys_config_nova(Name, dev, _Flags) ->
+    [
+        " {nova, [\n",
+        "     {use_stacktrace, true},\n",
+        "     {environment, dev},\n",
+        "     {cowboy_configuration, #{\n",
+        "         port => 8080\n",
+        "     }},\n",
+        "     {dev_mode, true},\n",
+        "     {bootstrap_application, ",
+        Name,
+        "},\n",
+        "     {plugins, [\n",
+        "         {pre_request, nova_request_plugin, #{decode_json_body => true}}\n",
+        "     ]}\n",
+        " ]},\n"
+    ];
+sys_config_nova(Name, prod, _Flags) ->
+    [
+        " {nova, [\n",
+        "     {use_stacktrace, false},\n",
+        "     {environment, prod},\n",
+        "     {cowboy_configuration, #{\n",
+        "         port => 8080\n",
+        "     }},\n",
+        "     {dev_mode, false},\n",
+        "     {bootstrap_application, ",
+        Name,
+        "},\n",
+        "     {plugins, [\n",
+        "         {pre_request, nova_request_plugin, #{decode_json_body => true}}\n",
+        "     ]}\n",
+        " ]},\n"
+    ].
+
+sys_config_pgo(Name, dev, #{kura := true}) ->
+    [
+        " {pgo, [\n",
+        "     {pools, [\n",
+        "         {default, #{\n",
+        "             pool_size => 10,\n",
+        "             host => \"127.0.0.1\",\n",
+        "             port => 5432,\n",
+        "             database => \"",
+        Name,
+        "_dev\",\n",
+        "             user => \"postgres\",\n",
+        "             password => \"postgres\"\n",
+        "         }}\n",
+        "     ]}\n",
+        " ]},\n"
+    ];
+sys_config_pgo(Name, dev, #{pgo := true}) ->
+    [
+        " {pgo, [\n",
+        "     {pools, [\n",
+        "         {default, #{\n",
+        "             pool_size => 10,\n",
+        "             host => \"127.0.0.1\",\n",
+        "             port => 5432,\n",
+        "             database => \"",
+        Name,
+        "_dev\",\n",
+        "             user => \"postgres\",\n",
+        "             password => \"postgres\"\n",
+        "         }}\n",
+        "     ]}\n",
+        " ]},\n"
+    ];
+sys_config_pgo(Name, prod, #{kura := true}) ->
+    [
+        " {pgo, [\n",
+        "     {pools, [\n",
+        "         {default, #{\n",
+        "             pool_size => ${PGO_POOL_SIZE},\n",
+        "             host => \"${DATABASE_HOST}\",\n",
+        "             port => ${DATABASE_PORT},\n",
+        "             database => \"",
+        Name,
+        "\",\n",
+        "             user => \"${DATABASE_USER}\",\n",
+        "             password => \"${DATABASE_PASSWORD}\"\n",
+        "         }}\n",
+        "     ]}\n",
+        " ]},\n"
+    ];
+sys_config_pgo(Name, prod, #{pgo := true}) ->
+    [
+        " {pgo, [\n",
+        "     {pools, [\n",
+        "         {default, #{\n",
+        "             pool_size => ${PGO_POOL_SIZE},\n",
+        "             host => \"${DATABASE_HOST}\",\n",
+        "             port => ${DATABASE_PORT},\n",
+        "             database => \"",
+        Name,
+        "\",\n",
+        "             user => \"${DATABASE_USER}\",\n",
+        "             password => \"${DATABASE_PASSWORD}\"\n",
+        "         }}\n",
+        "     ]}\n",
+        " ]},\n"
+    ];
+sys_config_pgo(_Name, _Env, _Flags) ->
+    [].
+
+sys_config_arizona(Name, _Env, #{arizona := true}) ->
+    [
+        " {arizona_core, [\n",
+        "     {otp_app, ",
+        Name,
+        "},\n",
+        "     {endpoint, #{\n",
+        "         live_reload => true\n",
+        "     }}\n",
+        " ]},\n"
+    ];
+sys_config_arizona(_Name, _Env, _Flags) ->
+    [].
+
+sys_config_otel(dev, #{otel := true}) ->
+    [
+        " {opentelemetry, [\n",
+        "     {span_processor, simple},\n",
+        "     {traces_exporter, {otel_exporter_stdout, []}}\n",
+        " ]},\n"
+    ];
+sys_config_otel(prod, #{otel := true}) ->
+    [
+        " {opentelemetry, [\n",
+        "     {span_processor, batch},\n",
+        "     {traces_exporter, {opentelemetry_exporter, #{endpoints => [\"${OTEL_ENDPOINT}\"]}}}\n",
+        " ]},\n"
+    ];
+sys_config_otel(_Env, _Flags) ->
+    [].
+
+%%======================================================================
+%% vm.args.src
+%%======================================================================
+
+generate_vm_args(Name) ->
+    Path = filename:join([Name, "config", "vm.args.src"]),
+    Content = [
+        "-sname '",
+        Name,
+        "'\n\n",
+        "-setcookie ",
+        Name,
+        "_cookie\n\n",
+        "+K true\n",
+        "+A30\n"
+    ],
+    rebar3_nova_utils:write_file(Path, Content).
+
+%%======================================================================
+%% .tool-versions
+%%======================================================================
+
+generate_tool_versions(Name) ->
+    Path = filename:join(Name, ".tool-versions"),
+    Content = [
+        "erlang 28.0.4\n",
+        "rebar 3.25.0\n"
+    ],
+    rebar3_nova_utils:write_file(Path, Content).
+
+%%======================================================================
+%% .gitignore
+%%======================================================================
+
+generate_gitignore(Name) ->
+    Path = filename:join(Name, ".gitignore"),
+    Content = [
+        ".rebar3\n",
+        "_*\n",
+        ".eunit\n",
+        "*.o\n",
+        "*.beam\n",
+        "*.plt\n",
+        "*.swp\n",
+        "*.swo\n",
+        ".erlang.cookie\n",
+        "ebin\n",
+        "log\n",
+        "erl_crash.dump\n",
+        ".rebar\n",
+        "logs\n",
+        "_build\n",
+        ".idea\n",
+        "*.iml\n",
+        "rebar3.crashdump\n",
+        "*~\n"
+    ],
+    rebar3_nova_utils:write_file(Path, Content).
+
+%%======================================================================
+%% favicon
+%%======================================================================
+
+copy_favicon(Name) ->
+    DestPath = filename:join([Name, "priv", "assets", "favicon.ico"]),
+    rebar3_nova_utils:copy_priv_file(
+        filename:join(["templates", "nova", "favicon.ico"]),
+        DestPath
+    ).
+
+%%======================================================================
+%% maybe_generate_view (ErlyDTL template, skip for arizona)
+%%======================================================================
+
+maybe_generate_view(_Name, #{arizona := true}) ->
+    ok;
+maybe_generate_view(Name, _Flags) ->
+    DestPath = filename:join([Name, "src", "views", Name ++ "_main.dtl"]),
+    rebar3_nova_utils:copy_priv_file(
+        filename:join(["templates", "nova", "controller.dtl"]),
+        DestPath
+    ).
+
+%%======================================================================
+%% maybe_generate_kura
+%%======================================================================
+
+maybe_generate_kura(Name, #{kura := true}) ->
+    generate_kura_repo(Name),
+    generate_docker_compose(Name);
+maybe_generate_kura(_Name, _Flags) ->
+    ok.
+
+generate_kura_repo(Name) ->
+    Path = filename:join([Name, "src", Name ++ "_repo.erl"]),
+    Content = [
+        "-module(",
+        Name,
+        "_repo).\n\n",
+        "-behaviour(kura_repo).\n\n",
+        "-export([otp_app/0]).\n\n",
+        "otp_app() -> ",
+        Name,
+        ".\n"
+    ],
+    rebar3_nova_utils:write_file(Path, Content).
+
+%%======================================================================
+%% maybe_generate_pgo
+%%======================================================================
+
+maybe_generate_pgo(Name, #{pgo := true}) ->
+    generate_docker_compose(Name);
+maybe_generate_pgo(_Name, _Flags) ->
+    ok.
+
+%%======================================================================
+%% docker-compose.yml (shared by kura and pgo)
+%%======================================================================
+
+generate_docker_compose(Name) ->
+    Path = filename:join(Name, "docker-compose.yml"),
+    case filelib:is_regular(Path) of
+        true ->
+            ok;
+        false ->
+            Content = [
+                "services:\n",
+                "  postgres:\n",
+                "    image: postgres:17\n",
+                "    environment:\n",
+                "      POSTGRES_USER: postgres\n",
+                "      POSTGRES_PASSWORD: postgres\n",
+                "      POSTGRES_DB: ",
+                Name,
+                "_dev\n",
+                "    ports:\n",
+                "      - \"5432:5432\"\n",
+                "    volumes:\n",
+                "      - pgdata:/var/lib/postgresql/data\n\n",
+                "volumes:\n",
+                "  pgdata:\n"
+            ],
+            rebar3_nova_utils:write_file(Path, Content)
+    end.
+
+%%======================================================================
+%% maybe_generate_arizona
+%%======================================================================
+
+maybe_generate_arizona(Name, #{arizona := true}) ->
+    generate_home_view(Name),
+    generate_app_css(Name);
+maybe_generate_arizona(_Name, _Flags) ->
+    ok.
+
+generate_home_view(Name) ->
+    Path = filename:join([Name, "src", "views", Name ++ "_home_view.erl"]),
+    Content = [
+        "-module(",
+        Name,
+        "_home_view).\n\n",
+        "-behaviour(arizona_view).\n\n",
+        "-export([mount/2, render/1]).\n\n",
+        "mount(_Params, State) ->\n",
+        "    {ok, arizona_state:put_assign(message, <<\"Hello from Arizona!\">>, State)}.\n\n",
+        "render(State) ->\n",
+        "    {ok, <<\"\n",
+        "        <div id=\\\"app\\\">\n",
+        "            <h1>{@message}</h1>\n",
+        "        </div>\n",
+        "    \">>, State}.\n"
+    ],
+    rebar3_nova_utils:write_file(Path, Content).
+
+generate_app_css(Name) ->
+    Path = filename:join([Name, "priv", "assets", "app.css"]),
+    Content = [
+        "* {\n",
+        "    margin: 0;\n",
+        "    padding: 0;\n",
+        "    box-sizing: border-box;\n",
+        "}\n\n",
+        "body {\n",
+        "    font-family: system-ui, -apple-system, sans-serif;\n",
+        "    background: #1b2735;\n",
+        "    color: #f5f6fa;\n",
+        "    display: flex;\n",
+        "    justify-content: center;\n",
+        "    align-items: center;\n",
+        "    min-height: 100vh;\n",
+        "}\n\n",
+        "#app h1 {\n",
+        "    font-size: 2rem;\n",
+        "    font-weight: 300;\n",
+        "    letter-spacing: 0.1em;\n",
+        "}\n"
+    ],
+    rebar3_nova_utils:write_file(Path, Content).
+
+%%======================================================================
+%% maybe_generate_ci
+%%======================================================================
+
+maybe_generate_ci(Name, #{ci := true}) ->
+    Path = filename:join([Name, ".github", "workflows", "ci.yml"]),
+    Content = [
+        "name: CI\n\n",
+        "on:\n",
+        "  push:\n",
+        "    branches: [main, master]\n",
+        "  pull_request:\n",
+        "    branches: [main, master]\n\n",
+        "permissions:\n",
+        "  contents: read\n\n",
+        "jobs:\n",
+        "  ci:\n",
+        "    uses: Taure/erlang-ci/.github/workflows/erlang-ci.yml@v1\n"
+    ],
+    rebar3_nova_utils:write_file(Path, Content);
+maybe_generate_ci(_Name, _Flags) ->
+    ok.
+
+%%======================================================================
+%% maybe_generate_docker
+%%======================================================================
+
+maybe_generate_docker(Name, #{docker := true}) ->
+    Path = filename:join(Name, "Dockerfile"),
+    Content = [
+        "FROM erlang:28 AS builder\n\n",
+        "WORKDIR /app\n\n",
+        "COPY rebar.config rebar.lock ./\n",
+        "RUN rebar3 compile\n\n",
+        "COPY . .\n",
+        "RUN rebar3 as prod release\n\n",
+        "FROM debian:bookworm-slim\n\n",
+        "RUN apt-get update && apt-get install -y --no-install-recommends \\\n",
+        "    libssl3 libncurses6 libstdc++6 && \\\n",
+        "    rm -rf /var/lib/apt/lists/*\n\n",
+        "WORKDIR /app\n",
+        "COPY --from=builder /app/_build/prod/rel/",
+        Name,
+        " ./\n\n",
+        "EXPOSE 8080\n\n",
+        "CMD [\"bin/",
+        Name,
+        "\", \"foreground\"]\n"
+    ],
+    rebar3_nova_utils:write_file(Path, Content);
+maybe_generate_docker(_Name, _Flags) ->
+    ok.
+
+%%======================================================================
+%% Summary
+%%======================================================================
+
+print_summary(Name, Flags) ->
+    rebar_api:info("~n==> Project ~s created successfully!~n", [Name]),
+    rebar_api:info("Next steps:~n", []),
+    rebar_api:info("  cd ~s~n", [Name]),
+    NeedsDb = maps:get(kura, Flags) orelse maps:get(pgo, Flags),
+    case NeedsDb of
+        true ->
+            rebar_api:info("  docker compose up -d~n", []);
+        false ->
+            ok
+    end,
+    case maps:get(kura, Flags) of
+        true ->
+            rebar_api:info("  rebar3 kura setup~n", []);
+        false ->
+            ok
+    end,
+    rebar_api:info("  rebar3 nova serve~n", []).

--- a/src/rebar3_nova_utils.erl
+++ b/src/rebar3_nova_utils.erl
@@ -4,7 +4,9 @@
     get_app_name/1,
     get_app_dir/1,
     ensure_dir/1,
+    write_file/2,
     write_file_if_not_exists/2,
+    copy_priv_file/2,
     parse_actions/1,
     load_sys_config/1
 ]).
@@ -23,18 +25,31 @@ get_app_dir(State) ->
 ensure_dir(Path) ->
     filelib:ensure_dir(Path).
 
+-spec write_file(file:filename(), iodata()) -> ok.
+write_file(Path, Content) ->
+    ok = ensure_dir(Path),
+    ok = file:write_file(Path, Content),
+    log_info("Created ~s", [Path]),
+    ok.
+
 -spec write_file_if_not_exists(file:filename(), iodata()) -> ok | skipped.
 write_file_if_not_exists(Path, Content) ->
     case filelib:is_regular(Path) of
         true ->
-            rebar_api:warn("File already exists, skipping: ~s", [Path]),
+            log_warn("File already exists, skipping: ~s", [Path]),
             skipped;
         false ->
-            ok = ensure_dir(Path),
-            ok = file:write_file(Path, Content),
-            rebar_api:info("Created ~s", [Path]),
-            ok
+            write_file(Path, Content)
     end.
+
+-spec copy_priv_file(file:filename(), file:filename()) -> ok.
+copy_priv_file(PrivRelPath, DestPath) ->
+    PrivDir = code:priv_dir(rebar3_nova),
+    SrcPath = filename:join(PrivDir, PrivRelPath),
+    ok = ensure_dir(DestPath),
+    {ok, _} = file:copy(SrcPath, DestPath),
+    log_info("Created ~s", [DestPath]),
+    ok.
 
 -spec parse_actions(string()) -> [atom()].
 parse_actions(Str) ->
@@ -55,4 +70,22 @@ load_sys_config(State) ->
         {error, _} ->
             rebar_api:warn("Could not read config from ~s", [ConfigPath]),
             []
+    end.
+
+%%----------------------------------------------------------------------
+%% Internal: safe logging (rebar_api may not be available in tests)
+%%----------------------------------------------------------------------
+
+log_info(Fmt, Args) ->
+    try
+        rebar_api:info(Fmt, Args)
+    catch
+        error:undef -> io:format(Fmt ++ "~n", Args)
+    end.
+
+log_warn(Fmt, Args) ->
+    try
+        rebar_api:warn(Fmt, Args)
+    catch
+        error:undef -> io:format("Warning: " ++ Fmt ++ "~n", Args)
     end.

--- a/test/rebar3_nova_new_SUITE.erl
+++ b/test/rebar3_nova_new_SUITE.erl
@@ -1,0 +1,311 @@
+-module(rebar3_nova_new_SUITE).
+
+-include_lib("common_test/include/ct.hrl").
+-include_lib("stdlib/include/assert.hrl").
+
+-export([all/0, init_per_testcase/2, end_per_testcase/2]).
+-export([
+    base_project/1,
+    kura_flag/1,
+    pgo_flag/1,
+    arizona_flag/1,
+    lfe_flag/1,
+    ci_flag/1,
+    docker_flag/1,
+    otel_flag/1,
+    combined_kura_arizona_ci/1,
+    kura_pgo_mutually_exclusive/1,
+    existing_dir_aborts/1
+]).
+
+all() ->
+    [
+        base_project,
+        kura_flag,
+        pgo_flag,
+        arizona_flag,
+        lfe_flag,
+        ci_flag,
+        docker_flag,
+        otel_flag,
+        combined_kura_arizona_ci,
+        kura_pgo_mutually_exclusive,
+        existing_dir_aborts
+    ].
+
+init_per_testcase(_TC, Config) ->
+    PrivDir = ?config(priv_dir, Config),
+    OldCwd = file:get_cwd(),
+    ok = file:set_cwd(PrivDir),
+    [{old_cwd, OldCwd} | Config].
+
+end_per_testcase(_TC, Config) ->
+    {ok, OldCwd} = ?config(old_cwd, Config),
+    ok = file:set_cwd(OldCwd),
+    Config.
+
+%%======================================================================
+%% Tests
+%%======================================================================
+
+base_project(_Config) ->
+    Name = "testapp_base",
+    Flags = default_flags(),
+    rebar3_nova_new:generate_project(Name, Flags),
+
+    assert_file_exists(Name, "rebar.config"),
+    assert_file_exists(Name, "src/testapp_base.app.src"),
+    assert_file_exists(Name, "src/testapp_base_app.erl"),
+    assert_file_exists(Name, "src/testapp_base_sup.erl"),
+    assert_file_exists(Name, "src/testapp_base_router.erl"),
+    assert_file_exists(Name, "src/controllers/testapp_base_main_controller.erl"),
+    assert_file_exists(Name, "src/views/testapp_base_main.dtl"),
+    assert_file_exists(Name, "config/dev_sys.config.src"),
+    assert_file_exists(Name, "config/prod_sys.config.src"),
+    assert_file_exists(Name, "config/vm.args.src"),
+    assert_file_exists(Name, ".tool-versions"),
+    assert_file_exists(Name, ".gitignore"),
+    assert_file_exists(Name, "priv/assets/favicon.ico"),
+
+    assert_file_not_exists(Name, "docker-compose.yml"),
+    assert_file_not_exists(Name, "Dockerfile"),
+    assert_file_not_exists(Name, ".github/workflows/ci.yml"),
+
+    RebarConfig = read_file(Name, "rebar.config"),
+    assert_contains(RebarConfig, "nova"),
+    assert_contains(RebarConfig, "flatlog"),
+    assert_contains(RebarConfig, "rebar3_erlydtl_plugin"),
+    assert_not_contains(RebarConfig, "kura"),
+    assert_not_contains(RebarConfig, "arizona"),
+
+    AppSrc = read_file(Name, "src/testapp_base.app.src"),
+    assert_contains(AppSrc, "kernel"),
+    assert_contains(AppSrc, "nova"),
+
+    SupErl = read_file(Name, "src/testapp_base_sup.erl"),
+    assert_contains(SupErl, "ChildSpecs = []"),
+
+    ok.
+
+kura_flag(_Config) ->
+    Name = "testapp_kura",
+    Flags = (default_flags())#{kura => true},
+    rebar3_nova_new:generate_project(Name, Flags),
+
+    assert_file_exists(Name, "src/testapp_kura_repo.erl"),
+    assert_file_exists(Name, "docker-compose.yml"),
+
+    RebarConfig = read_file(Name, "rebar.config"),
+    assert_contains(RebarConfig, "kura"),
+
+    AppSrc = read_file(Name, "src/testapp_kura.app.src"),
+    assert_contains(AppSrc, "kura"),
+
+    SupErl = read_file(Name, "src/testapp_kura_sup.erl"),
+    assert_contains(SupErl, "testapp_kura_repo"),
+
+    DevConfig = read_file(Name, "config/dev_sys.config.src"),
+    assert_contains(DevConfig, "pgo"),
+    assert_contains(DevConfig, "testapp_kura_dev"),
+
+    RepoErl = read_file(Name, "src/testapp_kura_repo.erl"),
+    assert_contains(RepoErl, "kura_repo"),
+    assert_contains(RepoErl, "testapp_kura"),
+
+    ok.
+
+pgo_flag(_Config) ->
+    Name = "testapp_pgo",
+    Flags = (default_flags())#{pgo => true},
+    rebar3_nova_new:generate_project(Name, Flags),
+
+    assert_file_exists(Name, "docker-compose.yml"),
+    assert_file_not_exists(Name, "src/testapp_pgo_repo.erl"),
+
+    RebarConfig = read_file(Name, "rebar.config"),
+    assert_contains(RebarConfig, "pgo"),
+    assert_not_contains(RebarConfig, "kura"),
+
+    DevConfig = read_file(Name, "config/dev_sys.config.src"),
+    assert_contains(DevConfig, "pgo"),
+
+    ok.
+
+arizona_flag(_Config) ->
+    Name = "testapp_arizona",
+    Flags = (default_flags())#{arizona => true},
+    rebar3_nova_new:generate_project(Name, Flags),
+
+    assert_file_exists(Name, "src/views/testapp_arizona_home_view.erl"),
+    assert_file_exists(Name, "priv/assets/app.css"),
+    assert_file_not_exists(Name, "src/views/testapp_arizona_main.dtl"),
+
+    RebarConfig = read_file(Name, "rebar.config"),
+    assert_contains(RebarConfig, "arizona_core"),
+    assert_contains(RebarConfig, "arizona_nova"),
+    assert_not_contains(RebarConfig, "erlydtl"),
+
+    Router = read_file(Name, "src/testapp_arizona_router.erl"),
+    assert_contains(Router, "arizona_nova_adapter"),
+    assert_contains(Router, "ws"),
+
+    DevConfig = read_file(Name, "config/dev_sys.config.src"),
+    assert_contains(DevConfig, "arizona_core"),
+
+    ok.
+
+lfe_flag(_Config) ->
+    Name = "testapp_lfe",
+    Flags = (default_flags())#{lfe => true},
+    rebar3_nova_new:generate_project(Name, Flags),
+
+    assert_file_exists(Name, "src/testapp_lfe_app.lfe"),
+    assert_file_exists(Name, "src/testapp_lfe.sup.lfe"),
+    assert_file_exists(Name, "src/testapp_lfe_router.lfe"),
+    assert_file_exists(Name, "src/controllers/testapp_lfe_main_controller.lfe"),
+    assert_file_not_exists(Name, "src/testapp_lfe_app.erl"),
+    assert_file_not_exists(Name, "src/testapp_lfe_sup.erl"),
+
+    RebarConfig = read_file(Name, "rebar.config"),
+    assert_contains(RebarConfig, "logjam"),
+    assert_contains(RebarConfig, "rebar3_lfe"),
+    assert_contains(RebarConfig, "provider_hooks"),
+    assert_not_contains(RebarConfig, "flatlog"),
+
+    DevConfig = read_file(Name, "config/dev_sys.config.src"),
+    assert_contains(DevConfig, "logjam"),
+
+    ok.
+
+ci_flag(_Config) ->
+    Name = "testapp_ci",
+    Flags = (default_flags())#{ci => true},
+    rebar3_nova_new:generate_project(Name, Flags),
+
+    assert_file_exists(Name, ".github/workflows/ci.yml"),
+
+    CiYml = read_file(Name, ".github/workflows/ci.yml"),
+    assert_contains(CiYml, "Taure/erlang-ci"),
+
+    ok.
+
+docker_flag(_Config) ->
+    Name = "testapp_docker",
+    Flags = (default_flags())#{docker => true},
+    rebar3_nova_new:generate_project(Name, Flags),
+
+    assert_file_exists(Name, "Dockerfile"),
+
+    Dockerfile = read_file(Name, "Dockerfile"),
+    assert_contains(Dockerfile, "erlang:28"),
+    assert_contains(Dockerfile, "testapp_docker"),
+    assert_contains(Dockerfile, "EXPOSE 8080"),
+
+    ok.
+
+otel_flag(_Config) ->
+    Name = "testapp_otel",
+    Flags = (default_flags())#{otel => true},
+    rebar3_nova_new:generate_project(Name, Flags),
+
+    RebarConfig = read_file(Name, "rebar.config"),
+    assert_contains(RebarConfig, "opentelemetry"),
+    assert_contains(RebarConfig, "opentelemetry_nova"),
+
+    AppSrc = read_file(Name, "src/testapp_otel.app.src"),
+    assert_contains(AppSrc, "opentelemetry"),
+
+    AppErl = read_file(Name, "src/testapp_otel_app.erl"),
+    assert_contains(AppErl, "opentelemetry:setup()"),
+
+    DevConfig = read_file(Name, "config/dev_sys.config.src"),
+    assert_contains(DevConfig, "otel_exporter_stdout"),
+
+    ProdConfig = read_file(Name, "config/prod_sys.config.src"),
+    assert_contains(ProdConfig, "OTEL_ENDPOINT"),
+
+    ok.
+
+combined_kura_arizona_ci(_Config) ->
+    Name = "testapp_combo",
+    Flags = (default_flags())#{kura => true, arizona => true, ci => true},
+    rebar3_nova_new:generate_project(Name, Flags),
+
+    assert_file_exists(Name, "src/testapp_combo_repo.erl"),
+    assert_file_exists(Name, "docker-compose.yml"),
+    assert_file_exists(Name, "src/views/testapp_combo_home_view.erl"),
+    assert_file_exists(Name, "priv/assets/app.css"),
+    assert_file_exists(Name, ".github/workflows/ci.yml"),
+    assert_file_not_exists(Name, "src/views/testapp_combo_main.dtl"),
+
+    RebarConfig = read_file(Name, "rebar.config"),
+    assert_contains(RebarConfig, "kura"),
+    assert_contains(RebarConfig, "arizona_core"),
+    assert_not_contains(RebarConfig, "erlydtl"),
+
+    Router = read_file(Name, "src/testapp_combo_router.erl"),
+    assert_contains(Router, "arizona_nova_adapter"),
+
+    SupErl = read_file(Name, "src/testapp_combo_sup.erl"),
+    assert_contains(SupErl, "testapp_combo_repo"),
+
+    ok.
+
+kura_pgo_mutually_exclusive(_Config) ->
+    Flags = (default_flags())#{kura => true, pgo => true},
+    ?assertMatch({error, _}, rebar3_nova_new:validate_flags(Flags)),
+    ok.
+
+existing_dir_aborts(_Config) ->
+    Name = "testapp_exists",
+    ok = file:make_dir(Name),
+    Flags = default_flags(),
+    ?assertError(
+        {dir_exists, Name},
+        rebar3_nova_new:generate_project(Name, Flags)
+    ),
+    ok.
+
+%%======================================================================
+%% Helpers
+%%======================================================================
+
+default_flags() ->
+    #{
+        kura => false,
+        pgo => false,
+        arizona => false,
+        lfe => false,
+        ci => false,
+        docker => false,
+        otel => false
+    }.
+
+assert_file_exists(Base, RelPath) ->
+    Path = filename:join(Base, RelPath),
+    ?assert(filelib:is_regular(Path), #{msg => "Expected file to exist", path => Path}).
+
+assert_file_not_exists(Base, RelPath) ->
+    Path = filename:join(Base, RelPath),
+    ?assertNot(filelib:is_regular(Path), #{msg => "Expected file to not exist", path => Path}).
+
+read_file(Base, RelPath) ->
+    Path = filename:join(Base, RelPath),
+    {ok, Bin} = file:read_file(Path),
+    binary_to_list(Bin).
+
+assert_contains(Content, Substr) ->
+    case string:find(Content, Substr) of
+        nomatch ->
+            ct:fail({expected_substring, Substr, Content});
+        _ ->
+            ok
+    end.
+
+assert_not_contains(Content, Substr) ->
+    case string:find(Content, Substr) of
+        nomatch ->
+            ok;
+        _ ->
+            ct:fail({unexpected_substring, Substr, Content})
+    end.


### PR DESCRIPTION
## Summary

- Adds `rebar3 nova new myapp [--kura] [--pgo] [--arizona] [--lfe] [--ci] [--docker] [--otel]` command that replaces multiple separate templates with a single composable interface
- Each flag conditionally adds deps, plugins, config sections, and source files — flags are freely combinable except `--kura`/`--pgo` (mutually exclusive)
- Adds `rebar3_nova_utils` module with safe file writing helpers and fallback logging for testability
- Adds xref_ignores for rebar3 API modules, fixes dialyzer `unknown` → `no_unknown`

## Flags

| Flag | Effect |
|------|--------|
| (none) | Base Nova project with ErlyDTL, flatlog |
| `--kura` | Kura repo module, docker-compose, sup child spec, pgo pool config |
| `--pgo` | docker-compose, pgo pool config (no repo module) |
| `--arizona` | Live view, app.css, WS route, drops erlydtl |
| `--lfe` | LFE source files, logjam, rebar3_lfe plugin |
| `--ci` | GitHub Actions CI workflow (Taure/erlang-ci) |
| `--docker` | Multi-stage Dockerfile |
| `--otel` | OpenTelemetry deps, setup call, exporter config |

## Test plan

- [x] `rebar3 compile` — plugin compiles cleanly
- [x] `rebar3 xref` — no warnings (with xref_ignores)
- [x] `rebar3 dialyzer` — only pre-existing warnings from `rebar3_nova_serve.erl`
- [x] `rebar3 ct --suite rebar3_nova_new_SUITE` — all 11 tests pass
  - Base project structure
  - Each flag individually (kura, pgo, arizona, lfe, ci, docker, otel)
  - Combined flags (kura + arizona + ci)
  - Mutual exclusion (kura + pgo → error)
  - Existing directory → error