### PR TITLE
fix(template): compile .dtl views via erlydtl provider hook

### DIFF
--- a/.github/workflows/erlang.yml
+++ b/.github/workflows/erlang.yml
@@ -6,7 +6,7 @@ jobs:
   ci:
     uses: Taure/erlang-ci/.github/workflows/ci.yml@v1
     with:
-      otp-version: '28.0'
+      otp-version: '28'
       rebar3-version: '3.26.0'
       enable-eunit: false
       enable-ex-doc: true

--- a/.github/workflows/erlang.yml
+++ b/.github/workflows/erlang.yml
@@ -9,5 +9,6 @@ jobs:
       otp-version: '28'
       rebar3-version: '3.26.0'
       enable-eunit: false
+      enable-ct: true
       enable-ex-doc: true
       enable-dialyzer: false

--- a/priv/templates/nova/rebar.config
+++ b/priv/templates/nova/rebar.config
@@ -61,6 +61,11 @@
     {erlfmt, "~>1.7"}
 ]}.
 
+%% Compile the .dtl views in src/views before the Erlang sources
+{provider_hooks, [
+    {pre, [{compile, {erlydtl, compile}}]}
+]}.
+
 {erlfmt, [
     write,
     {files, [

--- a/src/rebar3_nova_new.erl
+++ b/src/rebar3_nova_new.erl
@@ -289,7 +289,12 @@ rebar_provider_hooks(#{lfe := true}) ->
 rebar_provider_hooks(#{arizona := true}) ->
     [];
 rebar_provider_hooks(_) ->
-    [].
+    [
+        "%% Compile the .dtl views in src/views before the Erlang sources\n",
+        "{provider_hooks, [\n",
+        "    {pre, [{compile, {erlydtl, compile}}]}\n",
+        "]}.\n\n"
+    ].
 
 rebar_xref() ->
     [

--- a/test/rebar3_nova_new_SUITE.erl
+++ b/test/rebar3_nova_new_SUITE.erl
@@ -13,6 +13,8 @@
     ci_flag/1,
     docker_flag/1,
     otel_flag/1,
+    erlydtl_provider_hooks/1,
+    template_erlydtl_provider_hooks/1,
     combined_kura_arizona_ci/1,
     kura_pgo_mutually_exclusive/1,
     existing_dir_aborts/1
@@ -28,6 +30,8 @@ all() ->
         ci_flag,
         docker_flag,
         otel_flag,
+        erlydtl_provider_hooks,
+        template_erlydtl_provider_hooks,
         combined_kura_arizona_ci,
         kura_pgo_mutually_exclusive,
         existing_dir_aborts
@@ -75,6 +79,7 @@ base_project(_Config) ->
     assert_contains(RebarConfig, "nova"),
     assert_contains(RebarConfig, "flatlog"),
     assert_contains(RebarConfig, "rebar3_erlydtl_plugin"),
+    assert_contains(RebarConfig, "provider_hooks"),
     assert_not_contains(RebarConfig, "kura"),
     assert_not_contains(RebarConfig, "arizona"),
 
@@ -226,6 +231,46 @@ otel_flag(_Config) ->
 
     ok.
 
+erlydtl_provider_hooks(_Config) ->
+    Hook = {provider_hooks, [{pre, [{compile, {erlydtl, compile}}]}]},
+
+    Base = "testapp_hooks_base",
+    rebar3_nova_new:generate_project(Base, default_flags()),
+    ?assert(lists:member(Hook, consult_rebar_config(Base))),
+
+    Kura = "testapp_hooks_kura",
+    rebar3_nova_new:generate_project(Kura, (default_flags())#{kura => true}),
+    ?assert(lists:member(Hook, consult_rebar_config(Kura))),
+
+    Arizona = "testapp_hooks_arizona",
+    rebar3_nova_new:generate_project(Arizona, (default_flags())#{arizona => true}),
+    ?assertEqual(
+        false,
+        lists:keyfind(provider_hooks, 1, consult_rebar_config(Arizona))
+    ),
+
+    Lfe = "testapp_hooks_lfe",
+    rebar3_nova_new:generate_project(Lfe, (default_flags())#{lfe => true}),
+    ?assert(
+        lists:member(
+            {provider_hooks, [
+                {pre, [{compile, {erlydtl, compile}}, {compile, {lfe, compile}}]}
+            ]},
+            consult_rebar_config(Lfe)
+        )
+    ),
+
+    ok.
+
+template_erlydtl_provider_hooks(_Config) ->
+    PrivDir = code:priv_dir(rebar3_nova),
+    Template = filename:join([PrivDir, "templates", "nova", "rebar.config"]),
+    {ok, Bin} = file:read_file(Template),
+    Content = binary_to_list(Bin),
+    assert_contains(Content, "{provider_hooks, ["),
+    assert_contains(Content, "{pre, [{compile, {erlydtl, compile}}]}"),
+    ok.
+
 combined_kura_arizona_ci(_Config) ->
     Name = "testapp_combo",
     Flags = (default_flags())#{kura => true, arizona => true, ci => true},
@@ -288,6 +333,10 @@ assert_file_exists(Base, RelPath) ->
 assert_file_not_exists(Base, RelPath) ->
     Path = filename:join(Base, RelPath),
     ?assertNot(filelib:is_regular(Path), #{msg => "Expected file to not exist", path => Path}).
+
+consult_rebar_config(Base) ->
+    {ok, Terms} = file:consult(filename:join(Base, "rebar.config")),
+    Terms.
 
 read_file(Base, RelPath) ->
     Path = filename:join(Base, RelPath),


### PR DESCRIPTION
New Erlang projects declared `erlydtl_opts` and pulled in `rebar3_erlydtl_plugin`, but never hooked erlydtl into the compile step. `src/views/*.dtl` was therefore never compiled and Nova could not resolve views at runtime.

Adds the missing pre-compile hook to both scaffolding paths:

- `priv/templates/nova/rebar.config` — the `rebar3 new nova <app>` template
- `src/rebar3_nova_new.erl` — the `rebar3 nova new` generator

```erlang
{provider_hooks, [
    {pre, [{compile, {erlydtl, compile}}]}
]}.
```

Arizona projects are unaffected: they have no `.dtl` views, so `rebar_provider_hooks/1` still returns nothing for them. LFE projects already had the hook.

## Verification

End-to-end against a freshly generated project:

```
$ rebar3 new nova myapp && cd myapp && rebar3 compile
===> Running erlydtl...
===> Compiling myapp

$ ls _build/default/lib/myapp/ebin/
myapp.app  myapp_app.beam  myapp_main_controller.beam
myapp_main_dtl.beam  myapp_router.beam  myapp_sup.beam

$ curl -s -o /dev/null -w "%{http_code}\n" http://localhost:8080/
200
```

`myapp_main_dtl.beam` is produced and the landing page renders. Before this change neither happened.

## Tests

- `erlydtl_provider_hooks` — consults the generated `rebar.config` and asserts the exact hook term for the base and kura variants, its absence for arizona, and the erlydtl+lfe pair for lfe
- `template_erlydtl_provider_hooks` — asserts the static template carries the hook
- `base_project` — extended to assert `provider_hooks`

`rebar3 ct` 27/27 pass. `fmt --check`, `xref`, `ex_doc` clean. `dialyzer` reports 4 warnings, all pre-existing on master in files this PR does not touch (it is disabled in CI).

Fixes novaframework/nova#401