### PR TITLE
docs: clear all ex_doc warnings

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,4 @@
 # Rebar3 plugin for Nova
-=====
 
 A rebar plugin for nova
 

--- a/rebar.config
+++ b/rebar.config
@@ -8,7 +8,29 @@
     {proglang, erlang},
     {main, <<"readme">>},
     {extras, [<<"README.md">>, <<"LICENSE">>]},
-    {source_url, <<"https://github.com/novaframework/rebar3_nova">>}
+    {source_url, <<"https://github.com/novaframework/rebar3_nova">>},
+    % Every provider spec references rebar_state:t(), but rebar3 is the host
+    % application rather than a dependency, so its modules are absent from the
+    % doc build and ex_doc cannot resolve the type. Scoped to modules, so
+    % warnings in README.md and LICENSE still surface.
+    {skip_undefined_reference_warnings_on, [
+        "rebar3_nova",
+        "rebar3_nova_audit",
+        "rebar3_nova_config",
+        "rebar3_nova_doctor",
+        "rebar3_nova_gen_auth",
+        "rebar3_nova_gen_controller",
+        "rebar3_nova_gen_resource",
+        "rebar3_nova_gen_test",
+        "rebar3_nova_middleware",
+        "rebar3_nova_new",
+        "rebar3_nova_openapi",
+        "rebar3_nova_prv",
+        "rebar3_nova_release",
+        "rebar3_nova_routes",
+        "rebar3_nova_serve",
+        "rebar3_nova_utils"
+    ]}
 ]}.
 
 {deps, [


### PR DESCRIPTION
`rebar3 ex_doc` emitted **123 warnings**. Now it emits none.

## 122 of them: `rebar_state:t/0`

```
warning: spec references type "rebar_state:t/0" but it is undefined or private
  └─ (rebar3_nova) src/rebar3_nova_serve.erl:26
```

One per reference, across all 16 modules. Every provider spec names `rebar_state:t()`:

```erlang
-spec init(rebar_state:t()) -> {ok, rebar_state:t()}.
```

rebar3 is the **host application, not a dependency**, so its modules are absent from the doc build and ex_doc cannot resolve the type. That will not change - rebar3 ships as an escript with no ebin directory to point `deps` at. The specs are correct; the warning is unresolvable noise.

## What I tried first

`skip_code_autolink_to` looked like the precise fix - suppress by type name. It does nothing here: the spec-autolink path never consults it, and `rebar3_ex_doc` reports it as `unknown ex_doc option`. Warnings stayed at 122.

The option that works is `skip_undefined_reference_warnings_on`, and two things about it are worth stating plainly:

- **It matches on module or file, not on the referenced type** (`ExDoc.Autolink.maybe_warn/4` tests `config.id`, `config.module_id` and the file path). So it cannot be narrowed to `rebar_state:t/0` - the granularity does not exist.
- **All 16 modules is every module**, so for module docs this is the whole warning class, not a targeted allowlist. I would rather say that than let the list imply otherwise.

What redeems it: **extras are not covered**. I verified that by pointing `README.md` at a non-existent file and confirming it still warned:

```
warning: documentation references file "does-not-exist.md" but it does not exist
  └─ README.md: (file)
```

So broken links in `README.md` and `LICENSE` keep surfacing - which for a plugin is where the docs actually live, `main` being `readme`.

The known wart: a newly added module will not be in the list and will start warning again. It is self-announcing, and the comment in `rebar.config` explains why the list exists.

## The 123rd

`README.md:2` had a stray `=====` setext underline sitting under an ATX `#` heading. Removed.

## Checks

`ex_doc` 0 warnings, `fmt --check`, `xref`, `ct` 28/28 all clean.